### PR TITLE
Fix coverity error spinwave

### DIFF
--- a/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWave.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWave.h
@@ -37,7 +37,7 @@ the spin wave frequencies and intensities.
 class SpinWave
 {
 public:
-  SpinWave(): KXP(0.0),KYP(0.0),KZP(0.0),M(0),N(0),NU(0),MI(0),IM(0){};
+  SpinWave() : KXP(0.0), KYP(0.0), KZP(0.0), M(0), N(0), NU(0), MI(0), IM(0){};
   SpinWave(const SpinWave &other) = default;
   //! Use SpinWaveBuilder to generate SpinWave instance
   friend class SpinWaveBuilder;

--- a/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWave.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWave.h
@@ -37,7 +37,7 @@ the spin wave frequencies and intensities.
 class SpinWave
 {
 public:
-  SpinWave();
+  SpinWave(): KXP(0.0),KYP(0.0),KZP(0.0),M(0),N(0),NU(0),MI(0),IM(0){};
   SpinWave(const SpinWave &other) = default;
   //! Use SpinWaveBuilder to generate SpinWave instance
   friend class SpinWaveBuilder;
@@ -54,7 +54,7 @@ private:
   void calculateEigenvalues();
   void calculateWeights();
   void calculateIntensities();
-  size_t M, N;
+  std::size_t M, N;
   int NU, MI, IM;
   Eigen::MatrixXcd LN;
   Eigen::VectorXd SS;

--- a/libSpinWaveGenie/src/Genie/SpinWave.cpp
+++ b/libSpinWaveGenie/src/Genie/SpinWave.cpp
@@ -14,7 +14,7 @@ using namespace std;
 namespace SpinWaveGenie
 {
 
-SpinWave::SpinWave(Cell &cell_in, boost::ptr_vector<Interaction> interactions_in)
+SpinWave::SpinWave(Cell &cell_in, boost::ptr_vector<Interaction> interactions_in) : KXP(0.0),KYP(0.0),KZP(0.0),NU(0),MI(0),IM(0)
 {
   cell = cell_in;
   interactions = interactions_in;

--- a/libSpinWaveGenie/src/Genie/SpinWave.cpp
+++ b/libSpinWaveGenie/src/Genie/SpinWave.cpp
@@ -14,8 +14,6 @@ using namespace std;
 namespace SpinWaveGenie
 {
 
-SpinWave::SpinWave() {}
-
 SpinWave::SpinWave(Cell &cell_in, boost::ptr_vector<Interaction> interactions_in)
 {
   cell = cell_in;

--- a/libSpinWaveGenie/src/Genie/SpinWave.cpp
+++ b/libSpinWaveGenie/src/Genie/SpinWave.cpp
@@ -14,7 +14,8 @@ using namespace std;
 namespace SpinWaveGenie
 {
 
-SpinWave::SpinWave(Cell &cell_in, boost::ptr_vector<Interaction> interactions_in) : KXP(0.0),KYP(0.0),KZP(0.0),NU(0),MI(0),IM(0)
+SpinWave::SpinWave(Cell &cell_in, boost::ptr_vector<Interaction> interactions_in)
+    : KXP(0.0), KYP(0.0), KZP(0.0), NU(0), MI(0), IM(0)
 {
   cell = cell_in;
   interactions = interactions_in;


### PR DESCRIPTION
We will initialize all native types in constructor so that the copy constructor doesn't copy uninitialized memory.
