### PR TITLE
Cleanup villian examples

### DIFF
--- a/examples/AFMChain/Dispersion.cpp
+++ b/examples/AFMChain/Dispersion.cpp
@@ -1,14 +1,7 @@
 #define _USE_MATH_DEFINES
 #include <cmath>
-#include <fstream>
-#include <iostream>
 #include <string>
-#include <sstream>
-#include <vector>
-#include "SpinWaveGenie/Containers/Containers.h"
-#include "SpinWaveGenie/Genie/Genie.h"
-#include "SpinWaveGenie/Interactions/Interactions.h"
-#include "SpinWaveGenie/Plot/Plot.h"
+#include "SpinWaveGenie/SpinWaveGenie.h"
 
 using namespace std;
 using namespace SpinWaveGenie;

--- a/examples/AFMChain/PowderAverage.cpp
+++ b/examples/AFMChain/PowderAverage.cpp
@@ -1,14 +1,7 @@
 #define _USE_MATH_DEFINES
 #include <cmath>
-#include <fstream>
-#include <iostream>
 #include <string>
-#include <sstream>
-#include <vector>
-#include "SpinWaveGenie/Containers/Containers.h"
-#include "SpinWaveGenie/Genie/Genie.h"
-#include "SpinWaveGenie/Interactions/Interactions.h"
-#include "SpinWaveGenie/Plot/Plot.h"
+#include "SpinWaveGenie/SpinWaveGenie.h"
 
 using namespace std;
 using namespace SpinWaveGenie;

--- a/examples/AFMChain/TwoDimensionalCut.cpp
+++ b/examples/AFMChain/TwoDimensionalCut.cpp
@@ -1,10 +1,6 @@
 #define _USE_MATH_DEFINES
 #include <cmath>
-#include <fstream>
-#include <iostream>
 #include <string>
-#include <sstream>
-#include <vector>
 #include "SpinWaveGenie/SpinWaveGenie.h"
 
 using namespace std;

--- a/examples/Villain/FMDispersion.cpp
+++ b/examples/Villain/FMDispersion.cpp
@@ -1,14 +1,8 @@
 #define _USE_MATH_DEFINES
 #include <cmath>
-#include <fstream>
 #include <iostream>
 #include <string>
-#include <sstream>
-#include <vector>
-#include "SpinWaveGenie/Containers/Containers.h"
-#include "SpinWaveGenie/Genie/Genie.h"
-#include "SpinWaveGenie/Interactions/Interactions.h"
-#include "SpinWaveGenie/Plot/Plot.h"
+#include "SpinWaveGenie/SpinWaveGenie.h"
 
 using namespace std;
 using namespace SpinWaveGenie;

--- a/examples/Villain/SC1Dispersion.cpp
+++ b/examples/Villain/SC1Dispersion.cpp
@@ -1,9 +1,6 @@
 #define _USE_MATH_DEFINES
 #include <cmath>
-#include <iostream>
 #include <string>
-#include <sstream>
-#include <vector>
 #include "SpinWaveGenie/SpinWaveGenie.h"
 #include "nlopt.hpp"
 

--- a/examples/Villain/SC2Dispersion.cpp
+++ b/examples/Villain/SC2Dispersion.cpp
@@ -1,10 +1,6 @@
 #define _USE_MATH_DEFINES
 #include <cmath>
-#include <fstream>
-#include <iostream>
 #include <string>
-#include <sstream>
-#include <vector>
 #include "SpinWaveGenie/Containers/Containers.h"
 #include "SpinWaveGenie/Genie/Genie.h"
 #include "SpinWaveGenie/Interactions/Interactions.h"

--- a/libSpinWaveGenie/test/CMakeLists.txt
+++ b/libSpinWaveGenie/test/CMakeLists.txt
@@ -19,7 +19,6 @@ add_executable(EnergyResolutionFunctionTest EnergyResolutionFunctionTest.cpp)
 add_executable(IntegrateThetaPhiTest IntegrateThetaPhiTest.cpp)
 add_executable(IntegrateEnergyTest IntegrateEnergyTest.cpp)
 add_executable(AdaptiveSimpsonTest AdaptiveSimpsonTest.cpp)
-add_executable(IntegrationTest_FMChain IntegrationTest_FMChain.cpp)
 
 add_test(NAME SublatticeTest COMMAND ${EXECUTABLE_OUTPUT_PATH}/SublatticeTest)
 add_test(NAME CellTest COMMAND CellTest)
@@ -36,5 +35,4 @@ add_test(NAME EnergyResolutionFunctionTest COMMAND EnergyResolutionFunctionTest)
 add_test(NAME IntegrateThetaPhiTest COMMAND IntegrateThetaPhiTest)
 add_test(NAME IntegrateEnergyTest COMMAND IntegrateEnergyTest)
 add_test(NAME AdaptiveSimpsonTest COMMAND AdaptiveSimpsonTest)
-add_test(NAME IntegrationTest_FMChain COMMAND IntegrationTest_FMChain)
 

--- a/libSpinWaveGenie/test/CMakeLists.txt
+++ b/libSpinWaveGenie/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(EnergyResolutionFunctionTest EnergyResolutionFunctionTest.cpp)
 add_executable(IntegrateThetaPhiTest IntegrateThetaPhiTest.cpp)
 add_executable(IntegrateEnergyTest IntegrateEnergyTest.cpp)
 add_executable(AdaptiveSimpsonTest AdaptiveSimpsonTest.cpp)
+add_executable(IntegrationTest_FMChain IntegrationTest_FMChain.cpp)
 
 add_test(NAME SublatticeTest COMMAND ${EXECUTABLE_OUTPUT_PATH}/SublatticeTest)
 add_test(NAME CellTest COMMAND CellTest)
@@ -35,3 +36,5 @@ add_test(NAME EnergyResolutionFunctionTest COMMAND EnergyResolutionFunctionTest)
 add_test(NAME IntegrateThetaPhiTest COMMAND IntegrateThetaPhiTest)
 add_test(NAME IntegrateEnergyTest COMMAND IntegrateEnergyTest)
 add_test(NAME AdaptiveSimpsonTest COMMAND AdaptiveSimpsonTest)
+add_test(NAME IntegrationTest_FMChain COMMAND IntegrationTest_FMChain)
+

--- a/libSpinWaveGenie/test/MagneticFieldInteractionTest.cpp
+++ b/libSpinWaveGenie/test/MagneticFieldInteractionTest.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(FirstOrderTest)
     InteractionFactory factory;
     SpinWaveBuilder builder(cell);
     builder.addInteraction(factory.getMagneticField("H", -3.0, Vector3(0.0,0.0,1.0),"Spin0"));
-    double soln = -3.0*sqrt(2.0/2.0)*sin(M_PI/6);
+    double soln = -3.0*sin(M_PI/6.0);
     Eigen::VectorXcd result = builder.getFirstOrderTerms();
     BOOST_CHECK_CLOSE(result(0).real(),soln,1.0e-5);
     BOOST_CHECK_SMALL(result(0).imag(),1.0e-5);


### PR DESCRIPTION
removed extra includes from the AFM and Villain model examples. Cleanup of magnetic field interaction unit test to remove cast from int to double and sqrt(1). 
