### PR TITLE
set minimum cmake version to 2.8.12 and update version on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,10 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; 
     then 
       sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test;
+      sudo add-apt-repository --yes ppa:smspillaz/cmake-2.8.12;
       sudo apt-get update -qq;
+      sudo apt-get purge -qq cmake;
+      sudo apt-get install -qq cmake;
       sudo apt-get install -qq libboost-dev libboost-test-dev;
       sudo apt-get install -qq libeigen3-dev;
       sudo apt-get install -qq libtbb-dev;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(spin_wave_genie)
 
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 2.8.12)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 set(CMAKE_MACOSX_RPATH FALSE)
 #set(CMAKE_SKIP_RPATH TRUE)


### PR DESCRIPTION
We're updating the minimum cmake version to take advantage of modern cmake features. Unfortunately, also means updating the version on travis-ci.
