### PR TITLE
fix unused parameter warnings in clang and gcc

### DIFF
--- a/examples/Villain/SC1Dispersion.cpp
+++ b/examples/Villain/SC1Dispersion.cpp
@@ -63,11 +63,8 @@ SpinWaveBuilder getBuilder(double theta_a, double theta_b)
     
 }
 
-double myfunc(const std::vector<double> &x, std::vector<double> &grad, void *my_func_data)
+double myfunc(const std::vector<double> &x, std::vector<double> & /*grad*/, void * /*my_func_data*/)
 {
-    //unused parameters grad, my_func_data
-    (void)grad;
-    (void)my_func_data;
     SpinWaveBuilder builder = getBuilder(x[0],x[1]);
     return builder.getEnergy();
 }

--- a/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWave.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWave.h
@@ -38,12 +38,7 @@ class SpinWave
 {
 public:
   SpinWave() : KXP(0.0), KYP(0.0), KZP(0.0), M(0), N(0), NU(0), MI(0), IM(0){};
-  SpinWave(const SpinWave &other)
-      : KXP(other.KXP), KYP(other.KYP), KZP(other.KZP), cell(other.cell), M(other.M), N(other.N), NU(other.NU),
-        MI(other.MI), IM(other.IM), LN(other.LN), SS(other.SS), ces(other.ces), WW(other.WW), VI(other.VI),
-        XY(other.XY), XIN(other.XIN), interactions(other.interactions), formFactor(other.formFactor)
-  {
-  }
+  SpinWave(const SpinWave & /*other*/) = default;
   //! Use SpinWaveBuilder to generate SpinWave instance
   friend class SpinWaveBuilder;
   SpinWave(Cell &cell_in, boost::ptr_vector<Interaction> interactions_in);

--- a/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWave.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWave.h
@@ -38,7 +38,12 @@ class SpinWave
 {
 public:
   SpinWave() : KXP(0.0), KYP(0.0), KZP(0.0), M(0), N(0), NU(0), MI(0), IM(0){};
-  SpinWave(const SpinWave &other) = default;
+  SpinWave(const SpinWave &other)
+      : KXP(other.KXP), KYP(other.KYP), KZP(other.KZP), cell(other.cell), M(other.M), N(other.N), NU(other.NU),
+        MI(other.MI), IM(other.IM), LN(other.LN), SS(other.SS), ces(other.ces), WW(other.WW), VI(other.VI),
+        XY(other.XY), XIN(other.XIN), interactions(other.interactions), formFactor(other.formFactor)
+  {
+  }
   //! Use SpinWaveBuilder to generate SpinWave instance
   friend class SpinWaveBuilder;
   SpinWave(Cell &cell_in, boost::ptr_vector<Interaction> interactions_in);

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/TwoDimensionalGaussian.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/TwoDimensionalGaussian.h
@@ -31,7 +31,7 @@ class TwoDimensionResolutionFunction : public SpinWavePlot
 public:
   TwoDimensionResolutionFunction(){};
   TwoDimensionResolutionFunction(TwoDimGaussian &info, const SpinWave &SW, Energies energies);
-  TwoDimensionResolutionFunction(const TwoDimensionResolutionFunction &other) = default;
+  TwoDimensionResolutionFunction(const TwoDimensionResolutionFunction & /*other*/) = default;
   std::vector<double> getCut(double kxIn, double kyIn, double kzIn);
   void setTolerance(double tol, int maxEvals = 100000);
   std::unique_ptr<SpinWavePlot> clone();

--- a/libSpinWaveGenie/src/Interactions/AnisotropyInteraction.cpp
+++ b/libSpinWaveGenie/src/Interactions/AnisotropyInteraction.cpp
@@ -121,10 +121,8 @@ void AnisotropyInteraction::calculateFirstOrderTerms(Cell &cell, Eigen::VectorXc
   }
 }
 
-void AnisotropyInteraction::updateMatrix(Vector3 K, Eigen::MatrixXcd &LN)
+void AnisotropyInteraction::updateMatrix(Vector3 /*K*/, Eigen::MatrixXcd &LN)
 {
-  //unused variable K;
-  (void)K;
   LN(r, r) += LNrr;
   LN(r, r + M) += LNrrM;
   LN(r + M, r) += LNrMr;

--- a/libSpinWaveGenie/src/Interactions/DM_Y_Interaction.cpp
+++ b/libSpinWaveGenie/src/Interactions/DM_Y_Interaction.cpp
@@ -64,19 +64,9 @@ void DM_Y_Interaction::calcConstantValues(Cell &cell)
   // cout << value0 << " " << value1 << " " << value2 << " " << value3 << " " << endl;
 }
 
-void DM_Y_Interaction::calculateEnergy(Cell &cell, double &energy)
-{
-  //unused parameters cell,energy;
-  (void)cell;
-  (void)energy;
-}
+void DM_Y_Interaction::calculateEnergy(Cell & /*cell*/, double & /*energy*/) {}
 
-void DM_Y_Interaction::calculateFirstOrderTerms(Cell &cell, Eigen::VectorXcd &elements)
-{
-  //unused parameters cell,energy;
-  (void)cell;
-  (void)elements;
-}
+void DM_Y_Interaction::calculateFirstOrderTerms(Cell & /*cell*/, Eigen::VectorXcd & /*elements*/) {}
 
 void DM_Y_Interaction::updateMatrix(Vector3d K, MatrixXcd &LN)
 {

--- a/libSpinWaveGenie/src/Interactions/DM_Z_Interaction.cpp
+++ b/libSpinWaveGenie/src/Interactions/DM_Z_Interaction.cpp
@@ -38,12 +38,7 @@ const string &DM_Z_Interaction::getName() { return name; }
 
 void DM_Z_Interaction::updateValue(double value_in) { value = value_in; }
 
-void DM_Z_Interaction::calculateEnergy(Cell &cell, double &energy)
-{
-  //unused parameters cell, elements;
-  (void)cell;
-  (void)energy;
-}
+void DM_Z_Interaction::calculateEnergy(Cell & /*cell*/, double & /*energy*/) {}
 
 void DM_Z_Interaction::calcConstantValues(Cell &cell)
 {
@@ -71,12 +66,7 @@ void DM_Z_Interaction::calcConstantValues(Cell &cell)
   z_rs = neighbors.size();
 }
 
-void DM_Z_Interaction::calculateFirstOrderTerms(Cell &cell, Eigen::VectorXcd &elements)
-{
-  //unused parameters cell, elements;
-  (void)cell;
-  (void)elements;
-}
+void DM_Z_Interaction::calculateFirstOrderTerms(Cell & /*cell*/, Eigen::VectorXcd & /*elements*/) {}
 
 void DM_Z_Interaction::updateMatrix(Vector3d K, MatrixXcd &LN)
 {

--- a/libSpinWaveGenie/src/Interactions/ExchangeInteractionSameSublattice.cpp
+++ b/libSpinWaveGenie/src/Interactions/ExchangeInteractionSameSublattice.cpp
@@ -72,11 +72,8 @@ void ExchangeInteractionSameSublattice::calculateEnergy(Cell &cell, double &ener
   energy -= value * z_rs * Sr * Sr;
 }
 
-void ExchangeInteractionSameSublattice::calculateFirstOrderTerms(Cell &cell, VectorXcd &elements)
+void ExchangeInteractionSameSublattice::calculateFirstOrderTerms(Cell & /*cell*/, VectorXcd & /*elements*/)
 {
-  //unused paramets cell, elements
-  (void)cell;
-  (void)elements;
   // first order terms are 0.0
 }
 

--- a/libSpinWaveGenie/src/Interactions/MagneticFieldInteraction.cpp
+++ b/libSpinWaveGenie/src/Interactions/MagneticFieldInteraction.cpp
@@ -103,10 +103,8 @@ void MagneticFieldInteraction::calcConstantValues(Cell &cell)
   // cout << LNrr << endl;
 }
 
-void MagneticFieldInteraction::updateMatrix(Vector3 K, Eigen::MatrixXcd &LN)
+void MagneticFieldInteraction::updateMatrix(Vector3 /*K*/, Eigen::MatrixXcd &LN)
 {
-  //unused parameter K;
-  (void)K;
   LN(r, r) += LNrr;
   LN(r + M, r + M) += LNrr;
 }

--- a/libSpinWaveGenie/src/Plot/IntegrateThetaPhi.cpp
+++ b/libSpinWaveGenie/src/Plot/IntegrateThetaPhi.cpp
@@ -60,11 +60,8 @@ std::vector<double> IntegrateThetaPhi::calculateIntegrand(std::deque<double> &x)
   return val;
 }
 
-std::vector<double> IntegrateThetaPhi::getCut(double kx, double ky, double kz)
+std::vector<double> IntegrateThetaPhi::getCut(double /*kx*/, double /*ky*/, double kz)
 {
-  // unused parameters kx, ky;
-  (void)kx;
-  (void)ky;
   std::vector<double> xmin = {0.0, 0.0};
   std::vector<double> xmax = {M_PI, 2.0 * M_PI};
   r = std::abs(kz);

--- a/libSpinWaveGenie/test/EnergyResolutionFunctionTest.cpp
+++ b/libSpinWaveGenie/test/EnergyResolutionFunctionTest.cpp
@@ -15,7 +15,13 @@ class SimpleSpinWave
 public:
     SimpleSpinWave(){};
     SimpleSpinWave(Results input) {m_Results = input;};
-    void createMatrix(double KX,double KY,double KZ) {};
+    void createMatrix(double KX, double KY, double KZ)
+    {
+      // unused variables KX,KY,KZ
+      (void)KX;
+      (void)KY;
+      (void)KZ;
+    };
     void calculate() {};
     Results getPoints() {return m_Results;};
     const Cell& getCell() const {return m_Cell;};

--- a/libSpinWaveGenie/test/EnergyResolutionFunctionTest.cpp
+++ b/libSpinWaveGenie/test/EnergyResolutionFunctionTest.cpp
@@ -15,13 +15,7 @@ class SimpleSpinWave
 public:
     SimpleSpinWave(){};
     SimpleSpinWave(Results input) {m_Results = input;};
-    void createMatrix(double KX, double KY, double KZ)
-    {
-      // unused variables KX,KY,KZ
-      (void)KX;
-      (void)KY;
-      (void)KZ;
-    };
+    void createMatrix(double /*KX*/, double /*KY*/, double /*KZ*/){};
     void calculate() {};
     Results getPoints() {return m_Results;};
     const Cell& getCell() const {return m_Cell;};

--- a/libSpinWaveGenie/test/IntegrateEnergyTest.cpp
+++ b/libSpinWaveGenie/test/IntegrateEnergyTest.cpp
@@ -31,12 +31,8 @@ namespace SpinWaveGenie
         {
             m_Energies = energies;
         };
-        std::vector<double> getCut(double kx, double ky, double kz)
+        std::vector<double> getCut(double /*kx*/, double /*ky*/, double /*kz*/)
         {
-          // unused variables kx,ky,kz;
-          (void)kx;
-          (void)ky;
-          (void)kz;
             double frequency = 10.0;
             double FWHM = 1.0;
             std::vector<double> results;

--- a/libSpinWaveGenie/test/IntegrateEnergyTest.cpp
+++ b/libSpinWaveGenie/test/IntegrateEnergyTest.cpp
@@ -33,6 +33,10 @@ namespace SpinWaveGenie
         };
         std::vector<double> getCut(double kx, double ky, double kz)
         {
+          // unused variables kx,ky,kz;
+          (void)kx;
+          (void)ky;
+          (void)kz;
             double frequency = 10.0;
             double FWHM = 1.0;
             std::vector<double> results;

--- a/libSpinWaveGenie/test/IntegrateThetaPhiTest.cpp
+++ b/libSpinWaveGenie/test/IntegrateThetaPhiTest.cpp
@@ -32,14 +32,7 @@ namespace SpinWaveGenie
         {
             m_Energies = energies;
         };
-        std::vector<double> getCut(double kx, double ky, double kz)
-        {
-          // unused variables kx,ky,kz
-          (void)kx;
-          (void)ky;
-          (void)kz;
-            return std::vector<double>(1,1.0);
-        };
+        std::vector<double> getCut(double /*kx*/, double /*ky*/, double /*kz*/) { return std::vector<double>(1, 1.0); };
         ~ConstantFunction(){};
     private:
         SpinWaveGenie::Cell m_Cell;

--- a/libSpinWaveGenie/test/IntegrateThetaPhiTest.cpp
+++ b/libSpinWaveGenie/test/IntegrateThetaPhiTest.cpp
@@ -34,6 +34,10 @@ namespace SpinWaveGenie
         };
         std::vector<double> getCut(double kx, double ky, double kz)
         {
+          // unused variables kx,ky,kz
+          (void)kx;
+          (void)ky;
+          (void)kz;
             return std::vector<double>(1,1.0);
         };
         ~ConstantFunction(){};


### PR DESCRIPTION
Some unused parameter warnings made it through pull request #16. This is to fix/suppress those warnings. 
