### PR TITLE
fix typo and enable parallel make

### DIFF
--- a/SpinWaveGenie.spec.in
+++ b/SpinWaveGenie.spec.in
@@ -22,7 +22,7 @@ Prefix:         @CPACK_PACKAGING_INSTALL_PREFIX@
 
 %build
 %cmake %{?el6:-DBoost_NO_BOOST_CMAKE=ON} -DBUILD_TESTING=True
-%{__make} %{?_smp_flags}
+%{__make} %{?_smp_mflags}
 
 %install
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
There is a misspelled macro in SpinWaveGenie.spec.in. Fixing this should enable parallel make and therefore faster builds.
