### PR TITLE
Remove unused member function from Builder.

### DIFF
--- a/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWaveBuilder.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWaveBuilder.h
@@ -15,7 +15,6 @@ public:
   SpinWaveBuilder();
   SpinWaveBuilder(Cell &cellIn);
   void updateCell(Cell &cellIn);
-  void addInteraction(Interaction *in);
   void addInteraction(std::unique_ptr<Interaction> in);
   void updateInteraction(std::string name, double value);
   double getEnergy();

--- a/libSpinWaveGenie/src/Genie/SpinWaveBuilder.cpp
+++ b/libSpinWaveGenie/src/Genie/SpinWaveBuilder.cpp
@@ -20,14 +20,6 @@ void SpinWaveBuilder::addInteraction(std::unique_ptr<Interaction> in)
   interactions.sort();
 }
 
-void SpinWaveBuilder::addInteraction(Interaction *in)
-{
-  // cout << "cell check(Add_Interaction): " << cell.begin()->getName() << endl;
-  // cout << "cell check(Add_Interaction): " << cell.begin()->getName() << endl;
-  interactions.push_back(in);
-  interactions.sort();
-}
-
 void SpinWaveBuilder::updateInteraction(string name, double value)
 {
   for (auto it = interactions.begin(); it != interactions.end(); it++)


### PR DESCRIPTION
Originally SpinWaveBuilder accepted raw Interaction\* pointers which were inserted into a boost::ptr_vector. Users should instead use a very similar member function accepting unique_ptr<Interaction>.
