### PR TITLE
Easier printing of neighbors.

### DIFF
--- a/libSpinWaveGenie/include/SpinWaveGenie/Genie/Neighbors.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Genie/Neighbors.h
@@ -2,7 +2,7 @@
 #define __Neighbors_H__
 
 #define _USE_MATH_DEFINES
-#include <iostream>
+#include <ostream>
 #include "SpinWaveGenie/Containers/Matrices.h"
 #include "SpinWaveGenie/Containers/UniqueThreeVectors.h"
 
@@ -45,10 +45,10 @@ public:
   //! \return Returns an Iterator pointing to the final element of the neighbor list
   Iterator end();
   //! \return Returns an ConstIterator pointing to the first element of the neighbor list
-  ConstIterator cbegin();
+  ConstIterator cbegin() const;
   //! \return Returns an ConstIterator pointing to the final element of the neighbor list
-  ConstIterator cend();
-
+  ConstIterator cend() const;
+  friend std::ostream& operator<<( std::ostream &output, const Neighbors &n);
 private:
   UniqueThreeVectors<double> neighborList;
   double numberNeighbors;

--- a/libSpinWaveGenie/src/Genie/Neighbors.cpp
+++ b/libSpinWaveGenie/src/Genie/Neighbors.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include "boost/format.hpp"
 #include "SpinWaveGenie/Genie/Neighbors.h"
 #include "SpinWaveGenie/Containers/Cell.h"
 
@@ -99,4 +100,18 @@ double Neighbors::size() { return numberNeighbors; }
 Neighbors::Iterator Neighbors::begin() { return Iterator(neighborList.begin()); }
 
 Neighbors::Iterator Neighbors::end() { return Iterator(neighborList.end()); }
+  
+Neighbors::ConstIterator Neighbors::cbegin() const { return ConstIterator(neighborList.cbegin()); }
+  
+Neighbors::ConstIterator Neighbors::cend() const { return ConstIterator(neighborList.cend()); }
+  
+std::ostream& operator<<( std::ostream &output, const Neighbors &n)
+{
+  output << "  x         y         z\n";
+  for(auto nbr=n.cbegin();nbr!=n.cend();nbr++)
+  {
+    output << boost::format("%9.5f %9.5f %9.5f\n") % nbr->get<0>() % nbr->get<1>() % nbr->get<2>();
+  }
+  return output;
+}
 }

--- a/libSpinWaveGenie/test/NeighborsTest.cpp
+++ b/libSpinWaveGenie/test/NeighborsTest.cpp
@@ -2,7 +2,7 @@
 #define BOOST_TEST_MAIN
 #include <cmath>
 #include <exception>
-#include <iostream>
+#include <sstream>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/floating_point_comparison.hpp>
 #include "SpinWaveGenie/Containers/Cell.h"
@@ -194,5 +194,26 @@ BOOST_AUTO_TEST_CASE( TenthNeighbors )
     {
         double dist = sqrt(pow(nbr->get<0>(),2)+pow(nbr->get<1>(),2)+pow(nbr->get<2>(),2));
         BOOST_CHECK_SMALL(dist - 9.16545,eps);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(PrintList)
+{
+    Cell cell = createMnBiCell();
+    Neighbors neighborlist;
+    neighborlist.findNeighbors(cell,"Spin0", "Spin0", 9.0, 9.1);
+    std::stringstream teststream;
+    std::string header;
+    
+    teststream << neighborlist;
+    std::getline(teststream,header,'\n');
+    BOOST_CHECK_EQUAL("  x         y         z",header);
+  
+    for(auto nbr=neighborlist.begin();nbr!=neighborlist.end();nbr++)
+    {
+      double x,y,z;
+      teststream >> x >> y >> z;
+      double dist = sqrt(pow(nbr->get<0>()-x,2)+pow(nbr->get<1>()-y,2)+pow(nbr->get<2>()-z,2));
+      BOOST_CHECK_SMALL(dist,1.0e-5);
     }
 }


### PR DESCRIPTION
Overloading operator<< to make it easier to print the relative distance between spins.
