### PR TITLE
remote after_test from .appveyor.yml

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,4 +26,4 @@ build_script:
 - cmd: cmake --build . -- /p:Configuration=Release /m:2
 
 test_script:
-- cmd: ctest -C Release --output-on-failure -T test --no-compress-output
+- cmd: ctest -C Release --output-on-failure

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,7 +27,3 @@ build_script:
 
 test_script:
 - cmd: ctest -C Release --output-on-failure -T test --no-compress-output
-
-after_test:
-- ps: $wc = New-Object 'System.Net.WebClient'
-- ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path Testing\**\Test.xml))

--- a/libSpinWaveGenie/test/NeighborsTest.cpp
+++ b/libSpinWaveGenie/test/NeighborsTest.cpp
@@ -1,6 +1,5 @@
 #define BOOST_TEST_MODULE NeighborsTest
 #define BOOST_TEST_MAIN
-#define _USE_MATH_DEFINES
 #include <cmath>
 #include <exception>
 #include <sstream>


### PR DESCRIPTION
This fixes #48.

The ctest xml output doesn't pass the xunit schema, so it isn't surprising that appveyor won't parse it. This removes generating and submitting the xml output.
