### PR TITLE
Use gcc 4.8 on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,10 @@ before_install:
       sudo apt-get install -qq cmake libboost-dev libboost-test-dev libeigen3-dev libtbb-dev;
       cmake --version;
     fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "g++" ];
+  - if [ "$TRAVIS_OS_NAME" == "linux" ];
     then
-      sudo apt-get install -qq gcc-4.4 g++-4.4 libstdc++6-4.4-dev;
-    fi
+      sudo apt-get install -qq gcc-4.8 g++-4.8 libstdc++-4.8-dev;
+    fi  
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "clang++" ];
     then
       sudo apt-get install -qq gcc-4.8 g++-4.8 libstdc++-4.8-dev clang-3.4;
@@ -46,8 +46,8 @@ before_install:
 before_script:
   - if [ "$CXX" == "g++" ]; 
     then
-      export CC=gcc-4.4;
-      export CXX=g++-4.4;
+      export CC=gcc-4.8;
+      export CXX=g++-4.8;
     fi
   - if [ "$COVERALLS" == "true" ]; 
     then

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
     fi  
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "clang++" ];
     then
-      sudo apt-get install -qq gcc-4.8 g++-4.8 libstdc++-4.8-dev clang-3.4;
+      sudo apt-get install -qq clang-3.4;
     fi
 
 before_script:


### PR DESCRIPTION
The analysis machines have been upgraded to RHEL 7, allowing us to upgrade the minimum compiler version to GCC 4.8. This pull request changes the compiler version used on travis-ci. 
