### PR TITLE
Check dynamic_cast result.

### DIFF
--- a/libSpinWaveGenie/test/EnergyResolutionFunctionTest.cpp
+++ b/libSpinWaveGenie/test/EnergyResolutionFunctionTest.cpp
@@ -79,6 +79,7 @@ BOOST_AUTO_TEST_CASE(UpdatedGaussianFunction)
   OneDimensionalFactory factory;
   auto gaussian = factory.getGaussian(20.0, 1.0e-1);
   OneDimensionalGaussian *gaussian_ptr = dynamic_cast<OneDimensionalGaussian *>(gaussian.get());
+  BOOST_CHECK(gaussian_ptr != nullptr);
   gaussian_ptr->setFWHM(10.0);
   gaussian_ptr->setTolerance(5.0e-3);
   runTest(move(gaussian));
@@ -89,6 +90,7 @@ BOOST_AUTO_TEST_CASE(UpdatedLorentzianFunction)
   OneDimensionalFactory factory;
   auto lorentzian = factory.getLorentzian(20.0, 1.0e-1);
   OneDimensionalLorentzian *lorentzian_ptr = dynamic_cast<OneDimensionalLorentzian *>(lorentzian.get());
+  BOOST_CHECK(lorentzian_ptr != nullptr);
   lorentzian_ptr->setFWHM(10.0);
   lorentzian_ptr->setTolerance(5.0e-3);
   runTest(move(lorentzian));


### PR DESCRIPTION
Coverity reports that we don't check the results of two dynamic_casts. This makes the test fail if either cast fails. 
