### PR TITLE
Second attempt to fix coverity issues.

### DIFF
--- a/libSpinWaveGenie/test/EnergyResolutionFunctionTest.cpp
+++ b/libSpinWaveGenie/test/EnergyResolutionFunctionTest.cpp
@@ -80,9 +80,13 @@ BOOST_AUTO_TEST_CASE(UpdatedGaussianFunction)
   auto gaussian = factory.getGaussian(20.0, 1.0e-1);
   OneDimensionalGaussian *gaussian_ptr = dynamic_cast<OneDimensionalGaussian *>(gaussian.get());
   BOOST_CHECK(gaussian_ptr != nullptr);
-  gaussian_ptr->setFWHM(10.0);
-  gaussian_ptr->setTolerance(5.0e-3);
-  runTest(move(gaussian));
+  // fix coverity issue
+  if (gaussian_ptr)
+  {
+    gaussian_ptr->setFWHM(10.0);
+    gaussian_ptr->setTolerance(5.0e-3);
+    runTest(move(gaussian));
+  }
 }
 
 BOOST_AUTO_TEST_CASE(UpdatedLorentzianFunction)
@@ -91,7 +95,11 @@ BOOST_AUTO_TEST_CASE(UpdatedLorentzianFunction)
   auto lorentzian = factory.getLorentzian(20.0, 1.0e-1);
   OneDimensionalLorentzian *lorentzian_ptr = dynamic_cast<OneDimensionalLorentzian *>(lorentzian.get());
   BOOST_CHECK(lorentzian_ptr != nullptr);
-  lorentzian_ptr->setFWHM(10.0);
-  lorentzian_ptr->setTolerance(5.0e-3);
-  runTest(move(lorentzian));
+  // fix coverity issue
+  if (lorentzian_ptr)
+  {
+    lorentzian_ptr->setFWHM(10.0);
+    lorentzian_ptr->setTolerance(5.0e-3);
+    runTest(move(lorentzian));
+  }
 }


### PR DESCRIPTION
Puts the rest of test in an if block. Test should fail earlier if either pointer is null. 
