### PR TITLE
Replace boost::ptr_vector.

### DIFF
--- a/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWave.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWave.h
@@ -3,9 +3,9 @@
 
 #include <iostream>
 #include <utility>
+#include <memory>
 #include <vector>
 #include <cmath>
-#include <boost/ptr_container/ptr_vector.hpp>
 #include <Eigen/Dense>
 #include <Eigen/Eigenvalues>
 #include "SpinWaveGenie/Containers/Cell.h"
@@ -36,11 +36,12 @@ the spin wave frequencies and intensities.
 class SpinWave
 {
 public:
-  SpinWave() : KXP(0.0), KYP(0.0), KZP(0.0), M(0), N(0), NU(0), MI(0), IM(0){};
-  SpinWave(const SpinWave & /*other*/) = default;
+  SpinWave() : KXP(0.0), KYP(0.0), KZP(0.0), M(0), N(0), NU(0), MI(0), IM(0), interactions{} {};
+  SpinWave(const SpinWave &model);
+  SpinWave &operator=(const SpinWave &other);
   //! Use SpinWaveBuilder to generate SpinWave instance
   friend class SpinWaveBuilder;
-  SpinWave(Cell &cell_in, boost::ptr_vector<Interaction> interactions_in);
+  SpinWave(Cell &cell_in, std::vector<std::unique_ptr<Interaction>> interactions_in);
   void clearMatrix();
   const Cell &getCell() const;
   void createMatrix(double KX, double KY, double KZ);
@@ -61,7 +62,7 @@ private:
   Eigen::VectorXd WW; // want to get rid of this
   Results VI;
   Eigen::MatrixXcd XY, XIN;
-  boost::ptr_vector<Interaction> interactions;
+  std::vector<std::unique_ptr<Interaction>> interactions;
   MagneticFormFactor formFactor;
 };
 }

--- a/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWaveBuilder.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWaveBuilder.h
@@ -2,7 +2,8 @@
 #define __SpinWaveBuilder_H__ 1
 
 #include <string>
-#include <boost/ptr_container/ptr_vector.hpp>
+#include <vector>
+#include "SpinWaveGenie/Memory.h"
 #include "SpinWaveGenie/Genie/SpinWave.h"
 #include "SpinWaveGenie/Interactions/Interaction.h"
 
@@ -23,7 +24,7 @@ public:
 
 private:
   Cell cell;
-  boost::ptr_vector<Interaction> interactions;
+  std::vector<std::unique_ptr<Interaction>> interactions;
 };
 }
 #endif

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/AnisotropyInteraction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/AnisotropyInteraction.h
@@ -30,7 +30,7 @@ public:
   void calculateFirstOrderTerms(Cell &cell, Eigen::VectorXcd &elements) override;
   void updateMatrix(Eigen::Vector3d K, Eigen::MatrixXcd &LN) override;
   std::vector<std::string> sublattices() const override;
-  virtual Interaction *do_clone() const override;
+  virtual std::unique_ptr<Interaction> clone() const override;
   virtual ~AnisotropyInteraction(){};
 
 private:

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/DM_Y_Interaction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/DM_Y_Interaction.h
@@ -24,7 +24,7 @@ public:
   void calculateFirstOrderTerms(Cell &cell, Eigen::VectorXcd &elements) override;
   void updateMatrix(Eigen::Vector3d K, Eigen::MatrixXcd &LN) override;
   std::vector<std::string> sublattices() const override;
-  virtual Interaction *do_clone() const override;
+  virtual std::unique_ptr<Interaction> clone() const override;
   virtual ~DM_Y_Interaction(){};
 
 private:

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/DM_Z_Interaction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/DM_Z_Interaction.h
@@ -24,7 +24,7 @@ public:
   void calculateFirstOrderTerms(Cell &cell, Eigen::VectorXcd &elements) override;
   void updateMatrix(Eigen::Vector3d K, Eigen::MatrixXcd &LN) override;
   std::vector<std::string> sublattices() const override;
-  virtual Interaction *do_clone() const override;
+  virtual std::unique_ptr<Interaction> clone() const override;
   virtual ~DM_Z_Interaction(){};
 
 private:

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteraction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteraction.h
@@ -24,7 +24,7 @@ public:
   void calculateFirstOrderTerms(Cell &cell, Eigen::VectorXcd &elements) override;
   void updateMatrix(Eigen::Vector3d K, Eigen::MatrixXcd &LN) override;
   std::vector<std::string> sublattices() const override;
-  virtual Interaction *do_clone() const override;
+  virtual std::unique_ptr<Interaction> clone() const override;
   virtual ~ExchangeInteraction(){};
 
 private:

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteractionSameSublattice.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteractionSameSublattice.h
@@ -24,7 +24,7 @@ public:
   void calculateFirstOrderTerms(Cell &cell, Eigen::VectorXcd &elements) override;
   void updateMatrix(Eigen::Vector3d K, Eigen::MatrixXcd &LN) override;
   std::vector<std::string> sublattices() const override;
-  virtual Interaction *do_clone() const override;
+  virtual std::unique_ptr<Interaction> clone() const override;
   virtual ~ExchangeInteractionSameSublattice(){};
 
 private:

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/Interaction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/Interaction.h
@@ -1,6 +1,7 @@
 #ifndef __Interaction_H__
 #define __Interaction_H__ 1
 
+#include <memory>
 #include <string>
 #include <vector>
 #include <Eigen/Dense>

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/Interaction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/Interaction.h
@@ -29,7 +29,7 @@ public:
   virtual const std::string &getName() = 0;
   virtual void updateValue(double value) = 0;
   virtual void updateMatrix(Eigen::Vector3d K, Eigen::MatrixXcd &LN) = 0;
-  virtual Interaction *do_clone() const = 0;
+  virtual std::unique_ptr<Interaction> clone() const = 0;
   Interaction() = default;
   Interaction(const Interaction &) = default;
   // Interaction(Interaction&&) = default;
@@ -40,7 +40,6 @@ public:
 private:
 };
 
-inline Interaction *new_clone(const Interaction &o) { return o.do_clone(); }
 }
 
 #endif // __Interaction_H__

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/MagneticFieldInteraction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/MagneticFieldInteraction.h
@@ -30,7 +30,7 @@ public:
   void calculateFirstOrderTerms(Cell &cell, Eigen::VectorXcd &elements) override;
   void updateMatrix(Eigen::Vector3d K, Eigen::MatrixXcd &LN) override;
   std::vector<std::string> sublattices() const override;
-  virtual Interaction *do_clone() const override;
+  virtual std::unique_ptr<Interaction> clone() const override;
   virtual ~MagneticFieldInteraction(){};
 
 private:

--- a/libSpinWaveGenie/include/SpinWaveGenie/Memory.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Memory.h
@@ -6,7 +6,7 @@
 #include <type_traits>
 #include <utility>
 
-// implementation of std::make_unique for platforms that don't currently have it.
+// implementation of memory::make_unique for platforms that don't currently have it.
 // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3656.htm
 
 namespace SpinWaveGenie

--- a/libSpinWaveGenie/src/Genie/SpinWaveBuilder.cpp
+++ b/libSpinWaveGenie/src/Genie/SpinWaveBuilder.cpp
@@ -18,12 +18,17 @@ SpinWaveBuilder::SpinWaveBuilder(Cell &cellIn) : cell(cellIn)
 
 void SpinWaveBuilder::updateCell(Cell &cellIn) { cell = cellIn; }
 
+struct lessThanUniquePtr
+{
+  bool operator()(const unique_ptr<Interaction> &a, const unique_ptr<Interaction> &b) { return *a < *b; }
+};
+
 void SpinWaveBuilder::addInteraction(std::unique_ptr<Interaction> in)
 {
   // cout << "cell check(Add_Interaction): " << cell.begin()->getName() << endl;
   // cout << "cell check(Add_Interaction): " << cell.begin()->getName() << endl;
   interactions.push_back(std::move(in));
-  std::sort(interactions.begin(), interactions.end());
+  std::sort(interactions.begin(), interactions.end(), lessThanUniquePtr());
 }
 
 void SpinWaveBuilder::updateInteraction(string name, double value)

--- a/libSpinWaveGenie/src/Genie/SpinWaveBuilder.cpp
+++ b/libSpinWaveGenie/src/Genie/SpinWaveBuilder.cpp
@@ -8,7 +8,13 @@ namespace SpinWaveGenie
 
 SpinWaveBuilder::SpinWaveBuilder() {}
 
-SpinWaveBuilder::SpinWaveBuilder(Cell &cellIn) { cell = cellIn; }
+SpinWaveBuilder::SpinWaveBuilder(Cell &cellIn) : cell(cellIn)
+{
+  for (const auto &iter : interactions) // r
+  {
+    interactions.push_back(iter->clone());
+  }
+}
 
 void SpinWaveBuilder::updateCell(Cell &cellIn) { cell = cellIn; }
 
@@ -16,16 +22,16 @@ void SpinWaveBuilder::addInteraction(std::unique_ptr<Interaction> in)
 {
   // cout << "cell check(Add_Interaction): " << cell.begin()->getName() << endl;
   // cout << "cell check(Add_Interaction): " << cell.begin()->getName() << endl;
-  interactions.push_back(in.release());
-  interactions.sort();
+  interactions.push_back(std::move(in));
+  std::sort(interactions.begin(), interactions.end());
 }
 
 void SpinWaveBuilder::updateInteraction(string name, double value)
 {
   for (auto & elem : interactions)
   {
-    if (name.compare(elem.getName()) == 0)
-      elem.updateValue(value);
+    if (name.compare(elem->getName()) == 0)
+      elem->updateValue(value);
   }
 }
 
@@ -35,8 +41,8 @@ double SpinWaveBuilder::getEnergy()
   for (auto & elem : interactions)
   {
     // energy = 0.0;
-    elem.calculateEnergy(cell, energy);
-    cout << elem.getName() << " " << energy / 4.0 << endl;
+    elem->calculateEnergy(cell, energy);
+    cout << elem->getName() << " " << energy / 4.0 << endl;
   }
   // cout << endl;
   return energy;
@@ -58,7 +64,7 @@ Eigen::VectorXcd SpinWaveBuilder::getFirstOrderTerms()
     int M = cell.size();
     firstOrder.setZero(2*M);
     */
-    elem.calculateFirstOrderTerms(this->cell, firstOrder);
+    elem->calculateFirstOrderTerms(this->cell, firstOrder);
     // cout << firstOrder[2] << " " << firstOrder[8] << endl;
     // cout << firstOrder.transpose() << endl;
   }
@@ -68,11 +74,19 @@ Eigen::VectorXcd SpinWaveBuilder::getFirstOrderTerms()
 SpinWave SpinWaveBuilder::createElement()
 {
   // cout << "cell check(Create_Element): " << cell.begin()->getName() << endl;
-  for (auto & elem : interactions)
+
+  std::vector<std::unique_ptr<Interaction>> interactions_copy;
+  for (const auto &iter : interactions) // r
   {
-    elem.calcConstantValues(cell);
+    interactions_copy.push_back(iter->clone());
   }
-  SpinWave SW(cell, interactions);
+
+  for (auto &elem : interactions_copy)
+  {
+    elem->calcConstantValues(cell);
+  }
+
+  SpinWave SW(cell, std::move(interactions_copy));
   Eigen::VectorXcd firstOrder = getFirstOrderTerms();
   if (firstOrder.norm() > 0.1)
   {

--- a/libSpinWaveGenie/src/Interactions/AnisotropyInteraction.cpp
+++ b/libSpinWaveGenie/src/Interactions/AnisotropyInteraction.cpp
@@ -18,7 +18,10 @@ AnisotropyInteraction::AnisotropyInteraction(string name_in, double value_in, Ve
   this->updateInteraction(value_in, unitVectorIn, sl_r_in);
 }
 
-Interaction *AnisotropyInteraction::do_clone() const { return new AnisotropyInteraction(*this); }
+std::unique_ptr<Interaction> AnisotropyInteraction::clone() const
+{
+  return std::make_unique<AnisotropyInteraction>(*this);
+}
 
 void AnisotropyInteraction::updateInteraction(double value_in, Vector3 unitVectorIn, string sl_r_in)
 {

--- a/libSpinWaveGenie/src/Interactions/AnisotropyInteraction.cpp
+++ b/libSpinWaveGenie/src/Interactions/AnisotropyInteraction.cpp
@@ -7,6 +7,8 @@
 //
 
 #include "SpinWaveGenie/Interactions/AnisotropyInteraction.h"
+#include "SpinWaveGenie/Memory.h"
+
 using namespace std;
 
 namespace SpinWaveGenie
@@ -20,7 +22,7 @@ AnisotropyInteraction::AnisotropyInteraction(string name_in, double value_in, Ve
 
 std::unique_ptr<Interaction> AnisotropyInteraction::clone() const
 {
-  return std::make_unique<AnisotropyInteraction>(*this);
+  return memory::make_unique<AnisotropyInteraction>(*this);
 }
 
 void AnisotropyInteraction::updateInteraction(double value_in, Vector3 unitVectorIn, string sl_r_in)

--- a/libSpinWaveGenie/src/Interactions/DM_Y_Interaction.cpp
+++ b/libSpinWaveGenie/src/Interactions/DM_Y_Interaction.cpp
@@ -1,5 +1,6 @@
 #include "SpinWaveGenie/Interactions/DM_Y_Interaction.h"
 #include "SpinWaveGenie/Genie/Neighbors.h"
+#include "SpinWaveGenie/Memory.h"
 
 using namespace std;
 using namespace Eigen;
@@ -14,7 +15,7 @@ DM_Y_Interaction::DM_Y_Interaction(string name_in, double value_in, string sl_r_
   this->updateInteraction(value_in, sl_r_in, sl_s_in, min_in, max_in);
 }
 
-std::unique_ptr<Interaction> DM_Y_Interaction::clone() const { return std::make_unique<DM_Y_Interaction>(*this); }
+std::unique_ptr<Interaction> DM_Y_Interaction::clone() const { return memory::make_unique<DM_Y_Interaction>(*this); }
 
 void DM_Y_Interaction::updateInteraction(double value_in, string sl_r_in, string sl_s_in, double min_in, double max_in)
 {

--- a/libSpinWaveGenie/src/Interactions/DM_Y_Interaction.cpp
+++ b/libSpinWaveGenie/src/Interactions/DM_Y_Interaction.cpp
@@ -14,7 +14,7 @@ DM_Y_Interaction::DM_Y_Interaction(string name_in, double value_in, string sl_r_
   this->updateInteraction(value_in, sl_r_in, sl_s_in, min_in, max_in);
 }
 
-Interaction *DM_Y_Interaction::do_clone() const { return new DM_Y_Interaction(*this); }
+std::unique_ptr<Interaction> DM_Y_Interaction::clone() const { return std::make_unique<DM_Y_Interaction>(*this); }
 
 void DM_Y_Interaction::updateInteraction(double value_in, string sl_r_in, string sl_s_in, double min_in, double max_in)
 {

--- a/libSpinWaveGenie/src/Interactions/DM_Z_Interaction.cpp
+++ b/libSpinWaveGenie/src/Interactions/DM_Z_Interaction.cpp
@@ -1,5 +1,6 @@
 #include "SpinWaveGenie/Interactions/DM_Z_Interaction.h"
 #include "SpinWaveGenie/Genie/Neighbors.h"
+#include "SpinWaveGenie/Memory.h"
 
 using namespace std;
 using namespace Eigen;
@@ -15,7 +16,7 @@ DM_Z_Interaction::DM_Z_Interaction(string name_in, double value_in, string sl_r_
   this->updateInteraction(value_in, sl_r_in, sl_s_in, min_in, max_in);
 }
 
-std::unique_ptr<Interaction> DM_Z_Interaction::clone() const { return std::make_unique<DM_Z_Interaction>(*this); }
+std::unique_ptr<Interaction> DM_Z_Interaction::clone() const { return memory::make_unique<DM_Z_Interaction>(*this); }
 
 void DM_Z_Interaction::updateInteraction(double value_in, string sl_r_in, string sl_s_in, double min_in, double max_in)
 {

--- a/libSpinWaveGenie/src/Interactions/DM_Z_Interaction.cpp
+++ b/libSpinWaveGenie/src/Interactions/DM_Z_Interaction.cpp
@@ -15,7 +15,7 @@ DM_Z_Interaction::DM_Z_Interaction(string name_in, double value_in, string sl_r_
   this->updateInteraction(value_in, sl_r_in, sl_s_in, min_in, max_in);
 }
 
-Interaction *DM_Z_Interaction::do_clone() const { return new DM_Z_Interaction(*this); }
+std::unique_ptr<Interaction> DM_Z_Interaction::clone() const { return std::make_unique<DM_Z_Interaction>(*this); }
 
 void DM_Z_Interaction::updateInteraction(double value_in, string sl_r_in, string sl_s_in, double min_in, double max_in)
 {

--- a/libSpinWaveGenie/src/Interactions/ExchangeInteraction.cpp
+++ b/libSpinWaveGenie/src/Interactions/ExchangeInteraction.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include "SpinWaveGenie/Genie/Neighbors.h"
 #include "SpinWaveGenie/Interactions/ExchangeInteraction.h"
+#include "SpinWaveGenie/Memory.h"
 
 using namespace std;
 using namespace Eigen;
@@ -16,7 +17,10 @@ ExchangeInteraction::ExchangeInteraction(string name_in, double value_in, string
   this->updateInteraction(value_in, sl_r_in, sl_s_in, min_in, max_in);
 }
 
-std::unique_ptr<Interaction> ExchangeInteraction::clone() const { return std::make_unique<ExchangeInteraction>(*this); }
+std::unique_ptr<Interaction> ExchangeInteraction::clone() const
+{
+  return memory::make_unique<ExchangeInteraction>(*this);
+}
 
 void ExchangeInteraction::updateInteraction(double value_in, string sl_r_in, string sl_s_in, double min_in,
                                             double max_in)

--- a/libSpinWaveGenie/src/Interactions/ExchangeInteraction.cpp
+++ b/libSpinWaveGenie/src/Interactions/ExchangeInteraction.cpp
@@ -16,7 +16,7 @@ ExchangeInteraction::ExchangeInteraction(string name_in, double value_in, string
   this->updateInteraction(value_in, sl_r_in, sl_s_in, min_in, max_in);
 }
 
-Interaction *ExchangeInteraction::do_clone() const { return new ExchangeInteraction(*this); }
+std::unique_ptr<Interaction> ExchangeInteraction::clone() const { return std::make_unique<ExchangeInteraction>(*this); }
 
 void ExchangeInteraction::updateInteraction(double value_in, string sl_r_in, string sl_s_in, double min_in,
                                             double max_in)

--- a/libSpinWaveGenie/src/Interactions/ExchangeInteractionSameSublattice.cpp
+++ b/libSpinWaveGenie/src/Interactions/ExchangeInteractionSameSublattice.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include "SpinWaveGenie/Interactions/ExchangeInteractionSameSublattice.h"
 #include "SpinWaveGenie/Genie/Neighbors.h"
+#include "SpinWaveGenie/Memory.h"
 
 using namespace std;
 using namespace Eigen;
@@ -17,7 +18,7 @@ ExchangeInteractionSameSublattice::ExchangeInteractionSameSublattice(string name
 
 std::unique_ptr<Interaction> ExchangeInteractionSameSublattice::clone() const
 {
-  return std::make_unique<ExchangeInteractionSameSublattice>(*this);
+  return memory::make_unique<ExchangeInteractionSameSublattice>(*this);
 }
 
 void ExchangeInteractionSameSublattice::updateInteraction(double value_in, string sl_r_in, double min_in, double max_in)

--- a/libSpinWaveGenie/src/Interactions/ExchangeInteractionSameSublattice.cpp
+++ b/libSpinWaveGenie/src/Interactions/ExchangeInteractionSameSublattice.cpp
@@ -15,9 +15,9 @@ ExchangeInteractionSameSublattice::ExchangeInteractionSameSublattice(string name
   this->updateInteraction(value_in, sl_r_in, min_in, max_in);
 }
 
-Interaction *ExchangeInteractionSameSublattice::do_clone() const
+std::unique_ptr<Interaction> ExchangeInteractionSameSublattice::clone() const
 {
-  return new ExchangeInteractionSameSublattice(*this);
+  return std::make_unique<ExchangeInteractionSameSublattice>(*this);
 }
 
 void ExchangeInteractionSameSublattice::updateInteraction(double value_in, string sl_r_in, double min_in, double max_in)

--- a/libSpinWaveGenie/src/Interactions/MagneticFieldInteraction.cpp
+++ b/libSpinWaveGenie/src/Interactions/MagneticFieldInteraction.cpp
@@ -7,6 +7,7 @@
 //
 
 #include "SpinWaveGenie/Interactions/MagneticFieldInteraction.h"
+#include "SpinWaveGenie/Memory.h"
 
 using namespace std;
 
@@ -22,7 +23,7 @@ MagneticFieldInteraction::MagneticFieldInteraction(string name_in, double value_
 
 std::unique_ptr<Interaction> MagneticFieldInteraction::clone() const
 {
-  return std::make_unique<MagneticFieldInteraction>(*this);
+  return memory::make_unique<MagneticFieldInteraction>(*this);
 }
 
 void MagneticFieldInteraction::updateInteraction(double value_in, Vector3 unitVectorIn, string sl_r_in)

--- a/libSpinWaveGenie/src/Interactions/MagneticFieldInteraction.cpp
+++ b/libSpinWaveGenie/src/Interactions/MagneticFieldInteraction.cpp
@@ -20,7 +20,10 @@ MagneticFieldInteraction::MagneticFieldInteraction(string name_in, double value_
   this->updateInteraction(value_in, unitVectorIn, sl_r_in);
 }
 
-Interaction *MagneticFieldInteraction::do_clone() const { return new MagneticFieldInteraction(*this); }
+std::unique_ptr<Interaction> MagneticFieldInteraction::clone() const
+{
+  return std::make_unique<MagneticFieldInteraction>(*this);
+}
 
 void MagneticFieldInteraction::updateInteraction(double value_in, Vector3 unitVectorIn, string sl_r_in)
 {

--- a/libSpinWaveGenie/test/EnergyResolutionFunctionTest.cpp
+++ b/libSpinWaveGenie/test/EnergyResolutionFunctionTest.cpp
@@ -46,15 +46,15 @@ void runTest(std::unique_ptr<OneDimensionalShapes> resolutionFunction)
     
     //check lower bound;
     auto min_zeros = std::find_if(testme.begin(), testme.end(),std::bind(std::greater<double>(),std::placeholders::_1,1.0e-3));
-    BOOST_CHECK_EQUAL(std::distance(testme.begin(),min_zeros),energies.getLowerBound(min));
-    
+    BOOST_CHECK_EQUAL(std::distance(testme.begin(), min_zeros), static_cast<long>(energies.getLowerBound(min)));
+
     double shouldBeZero = std::accumulate(testme.begin(),min_zeros,0.0);
     BOOST_CHECK_CLOSE(shouldBeZero,0.0,1.0e-15);
     
     //check upper bound
     auto max_zeros = std::find_if_not(min_zeros+1, testme.end(),std::bind(std::greater<double>(),std::placeholders::_1,1.0e-3));
-    BOOST_CHECK_EQUAL(std::distance(testme.begin(),max_zeros),energies.getUpperBound(max));
-    
+    BOOST_CHECK_EQUAL(std::distance(testme.begin(), max_zeros), static_cast<long>(energies.getUpperBound(max)));
+
     shouldBeZero = std::accumulate(max_zeros,testme.end(),0.0);
     BOOST_CHECK_CLOSE(shouldBeZero,0.0,1.0e-15);
 }

--- a/libSpinWaveGenie/test/FormFactorTest.cpp
+++ b/libSpinWaveGenie/test/FormFactorTest.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE( CheckCoefficients )
     TestCoefficients test;
     std::map<std::string,double> badCoefficients;
     badCoefficients = test.testCoefficients();
-    BOOST_CHECK_EQUAL(badCoefficients.size(), 0);
+    BOOST_CHECK_EQUAL(badCoefficients.size(), std::size_t(0));
 }
 
 BOOST_AUTO_TEST_CASE(DefaultConstructor)


### PR DESCRIPTION
This fixes #35.

Replaces boost:ptr_vector with the C++11 equivalent std::vectorstd::unique_ptr.
