### PR TITLE
Fix logic error in operator<

### DIFF
--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/AnisotropyInteraction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/AnisotropyInteraction.h
@@ -29,7 +29,7 @@ public:
   void calculateEnergy(Cell &cell, double &energy) override;
   void calculateFirstOrderTerms(Cell &cell, Eigen::VectorXcd &elements) override;
   void updateMatrix(Eigen::Vector3d K, Eigen::MatrixXcd &LN) override;
-  std::vector<std::string> sublattices() const override;
+  std::array<std::string, 2> sublattices() const override;
   virtual std::unique_ptr<Interaction> clone() const override;
   virtual ~AnisotropyInteraction(){};
 

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/DM_Y_Interaction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/DM_Y_Interaction.h
@@ -23,7 +23,7 @@ public:
   void calculateEnergy(Cell &cell, double &energy) override;
   void calculateFirstOrderTerms(Cell &cell, Eigen::VectorXcd &elements) override;
   void updateMatrix(Eigen::Vector3d K, Eigen::MatrixXcd &LN) override;
-  std::vector<std::string> sublattices() const override;
+  std::array<std::string, 2> sublattices() const override;
   virtual std::unique_ptr<Interaction> clone() const override;
   virtual ~DM_Y_Interaction(){};
 

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/DM_Z_Interaction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/DM_Z_Interaction.h
@@ -23,7 +23,7 @@ public:
   void calculateEnergy(Cell &cell, double &energy) override;
   void calculateFirstOrderTerms(Cell &cell, Eigen::VectorXcd &elements) override;
   void updateMatrix(Eigen::Vector3d K, Eigen::MatrixXcd &LN) override;
-  std::vector<std::string> sublattices() const override;
+  std::array<std::string, 2> sublattices() const override;
   virtual std::unique_ptr<Interaction> clone() const override;
   virtual ~DM_Z_Interaction(){};
 

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteraction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteraction.h
@@ -23,7 +23,7 @@ public:
   void calculateEnergy(Cell &cell, double &energy) override;
   void calculateFirstOrderTerms(Cell &cell, Eigen::VectorXcd &elements) override;
   void updateMatrix(Eigen::Vector3d K, Eigen::MatrixXcd &LN) override;
-  std::vector<std::string> sublattices() const override;
+  std::array<std::string, 2> sublattices() const override;
   virtual std::unique_ptr<Interaction> clone() const override;
   virtual ~ExchangeInteraction(){};
 

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteractionSameSublattice.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteractionSameSublattice.h
@@ -23,7 +23,7 @@ public:
   void calculateEnergy(Cell &cell, double &energy) override;
   void calculateFirstOrderTerms(Cell &cell, Eigen::VectorXcd &elements) override;
   void updateMatrix(Eigen::Vector3d K, Eigen::MatrixXcd &LN) override;
-  std::vector<std::string> sublattices() const override;
+  std::array<std::string, 2> sublattices() const override;
   virtual std::unique_ptr<Interaction> clone() const override;
   virtual ~ExchangeInteractionSameSublattice(){};
 

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/Interaction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/Interaction.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 #include <string>
-#include <vector>
+#include <array>
 #include <Eigen/Dense>
 #include "SpinWaveGenie/Containers/Cell.h"
 
@@ -17,7 +17,7 @@ class Neighbors;
 class Interaction
 {
 public:
-  virtual std::vector<std::string> sublattices() const = 0;
+  virtual std::array<std::string, 2> sublattices() const = 0;
   bool operator<(const Interaction &other) const;
   bool operator==(const Interaction &other) const;
   virtual void calculateEnergy(Cell &cell, double &energy) = 0;

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/MagneticFieldInteraction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/MagneticFieldInteraction.h
@@ -29,7 +29,7 @@ public:
   void calculateEnergy(Cell &cell, double &energy) override;
   void calculateFirstOrderTerms(Cell &cell, Eigen::VectorXcd &elements) override;
   void updateMatrix(Eigen::Vector3d K, Eigen::MatrixXcd &LN) override;
-  std::vector<std::string> sublattices() const override;
+  std::array<std::string, 2> sublattices() const override;
   virtual std::unique_ptr<Interaction> clone() const override;
   virtual ~MagneticFieldInteraction(){};
 

--- a/libSpinWaveGenie/src/Interactions/AnisotropyInteraction.cpp
+++ b/libSpinWaveGenie/src/Interactions/AnisotropyInteraction.cpp
@@ -37,12 +37,7 @@ const string &AnisotropyInteraction::getName() { return name; }
 
 void AnisotropyInteraction::updateValue(double value_in) { value = value_in; }
 
-vector<string> AnisotropyInteraction::sublattices() const
-{
-  vector<string> sl;
-  sl.push_back(sl_r);
-  return sl;
-}
+std::array<std::string, 2> AnisotropyInteraction::sublattices() const { return {{sl_r, sl_r}}; }
 
 void AnisotropyInteraction::calcConstantValues(Cell &cell)
 {

--- a/libSpinWaveGenie/src/Interactions/DM_Y_Interaction.cpp
+++ b/libSpinWaveGenie/src/Interactions/DM_Y_Interaction.cpp
@@ -30,13 +30,7 @@ const string &DM_Y_Interaction::getName() { return name; }
 
 void DM_Y_Interaction::updateValue(double value_in) { value = value_in; }
 
-vector<string> DM_Y_Interaction::sublattices() const
-{
-  vector<string> sl;
-  sl.push_back(sl_r);
-  sl.push_back(sl_s);
-  return sl;
-}
+std::array<std::string, 2> DM_Y_Interaction::sublattices() const { return {{sl_r, sl_s}}; }
 
 void DM_Y_Interaction::calcConstantValues(Cell &cell)
 {

--- a/libSpinWaveGenie/src/Interactions/DM_Z_Interaction.cpp
+++ b/libSpinWaveGenie/src/Interactions/DM_Z_Interaction.cpp
@@ -27,13 +27,7 @@ void DM_Z_Interaction::updateInteraction(double value_in, string sl_r_in, string
   max = max_in;
 }
 
-vector<string> DM_Z_Interaction::sublattices() const
-{
-  vector<string> sl;
-  sl.push_back(sl_r);
-  sl.push_back(sl_s);
-  return sl;
-}
+std::array<std::string, 2> DM_Z_Interaction::sublattices() const { return {{sl_r, sl_s}}; }
 
 const string &DM_Z_Interaction::getName() { return name; }
 

--- a/libSpinWaveGenie/src/Interactions/ExchangeInteraction.cpp
+++ b/libSpinWaveGenie/src/Interactions/ExchangeInteraction.cpp
@@ -36,11 +36,7 @@ const string &ExchangeInteraction::getName() { return name; }
 
 void ExchangeInteraction::updateValue(double value_in) { value = value_in; }
 
-vector<string> ExchangeInteraction::sublattices() const
-{
-  vector<string> sl = {sl_r, sl_s};
-  return sl;
-}
+std::array<std::string, 2> ExchangeInteraction::sublattices() const { return {{sl_r, sl_s}}; }
 
 void ExchangeInteraction::calcConstantValues(Cell &cell)
 {

--- a/libSpinWaveGenie/src/Interactions/ExchangeInteractionSameSublattice.cpp
+++ b/libSpinWaveGenie/src/Interactions/ExchangeInteractionSameSublattice.cpp
@@ -33,11 +33,7 @@ const string &ExchangeInteractionSameSublattice::getName() { return name; }
 
 void ExchangeInteractionSameSublattice::updateValue(double value_in) { value = value_in; }
 
-vector<string> ExchangeInteractionSameSublattice::sublattices() const
-{
-  vector<string> sl = {sl_r, sl_r};
-  return sl;
-}
+std::array<std::string, 2> ExchangeInteractionSameSublattice::sublattices() const { return {{sl_r, sl_r}}; }
 
 void ExchangeInteractionSameSublattice::calcConstantValues(Cell &cell)
 {

--- a/libSpinWaveGenie/src/Interactions/Interaction.cpp
+++ b/libSpinWaveGenie/src/Interactions/Interaction.cpp
@@ -6,52 +6,26 @@ namespace SpinWaveGenie
 
 bool Interaction::operator<(const Interaction &other) const
 {
-  vector<string> sl1 = this->sublattices();
-  vector<string> sl2 = other.sublattices();
-  if (sl1.size() <= sl2.size())
+  auto sl1 = this->sublattices();
+  auto sl2 = other.sublattices();
+  for (std::size_t index = 0; index < sl1.size(); ++index)
   {
-    for (size_t index = 0; index < sl1.size(); index++)
-    {
-      if (sl1[index] < sl2[index])
-        return true;
-      else if (sl1[index] > sl2[index])
-        return false;
-    }
-    return true;
+    if (sl1[index] < sl2[index])
+      return true;
+    else if (sl1[index] != sl2[index])
+      return false;
   }
-  else // sl1.size() > sl2.size()
-  {
-    for (size_t index = 0; index < sl2.size(); index++)
-    {
-      if (sl1[index] < sl2[index])
-        return true;
-      else if (sl1[index] > sl2[index])
-        return false;
-    }
-    return false;
-  }
+  return false;
 }
 
 bool Interaction::operator==(const Interaction &other) const
 {
-  vector<string> sl1 = this->sublattices();
-  vector<string> sl2 = other.sublattices();
+  auto sl1 = this->sublattices();
+  auto sl2 = other.sublattices();
 
-  if (sl1.size() != sl2.size())
+  if (sl1[0].compare(sl2[0]) == 0 && sl1[1].compare(sl2[1]) == 0)
+    return true;
+  else
     return false;
-  else if (sl1.size() == 1)
-  {
-    if (sl1[0].compare(sl2[0]) == 0)
-      return true;
-    else
-      return false;
-  }
-  else // sl1.size() == 2
-  {
-    if (sl1[0].compare(sl2[0]) == 0 && sl1[1].compare(sl2[1]) == 0)
-      return true;
-    else
-      return false;
-  }
 }
 }

--- a/libSpinWaveGenie/src/Interactions/MagneticFieldInteraction.cpp
+++ b/libSpinWaveGenie/src/Interactions/MagneticFieldInteraction.cpp
@@ -38,12 +38,7 @@ const string &MagneticFieldInteraction::getName() { return name; }
 
 void MagneticFieldInteraction::updateValue(double value_in) { value = value_in; }
 
-vector<string> MagneticFieldInteraction::sublattices() const
-{
-  vector<string> sl;
-  sl.push_back(sl_r);
-  return sl;
-}
+std::array<std::string, 2> MagneticFieldInteraction::sublattices() const { return {{sl_r, sl_r}}; }
 
 void MagneticFieldInteraction::calculateEnergy(Cell &cell, double &energy)
 {


### PR DESCRIPTION
The current implementation incorrectly returns `true` when the arrays are equal, causing a seg fault in the YFeO3 example. This also simplifies operator< so that it is easier to verify correct behavior.
