### PR TITLE
Improve interaction sorting. Code cleanup.

### DIFF
--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/Interaction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/Interaction.h
@@ -32,9 +32,9 @@ public:
   virtual std::unique_ptr<Interaction> clone() const = 0;
   Interaction() = default;
   Interaction(const Interaction &) = default;
-  Interaction(Interaction &&) = default;
-  Interaction &operator=(const Interaction &)& = default;
-  Interaction &operator=(Interaction &&)& = default;
+  //Interaction(Interaction &&) = default;
+  //Interaction &operator=(const Interaction &)& = default;
+  //Interaction &operator=(Interaction &&)& = default;
   virtual ~Interaction(){};
 
 private:

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/Interaction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/Interaction.h
@@ -19,7 +19,6 @@ class Interaction
 public:
   virtual std::array<std::string, 2> sublattices() const = 0;
   bool operator<(const Interaction &other) const;
-  bool operator==(const Interaction &other) const;
   virtual void calculateEnergy(Cell &cell, double &energy) = 0;
   virtual void calcConstantValues(Cell &cell) = 0;
   virtual void calculateFirstOrderTerms(Cell &cell, Eigen::VectorXcd &elements) = 0;
@@ -33,9 +32,9 @@ public:
   virtual std::unique_ptr<Interaction> clone() const = 0;
   Interaction() = default;
   Interaction(const Interaction &) = default;
-  // Interaction(Interaction&&) = default;
-  // Interaction& operator=(const Interaction&) & = default;
-  // Interaction& operator=(Interaction&&) & = default;
+  Interaction(Interaction &&) = default;
+  Interaction &operator=(const Interaction &)& = default;
+  Interaction &operator=(Interaction &&)& = default;
   virtual ~Interaction(){};
 
 private:

--- a/libSpinWaveGenie/src/Genie/SpinWave.cpp
+++ b/libSpinWaveGenie/src/Genie/SpinWave.cpp
@@ -138,10 +138,6 @@ void SpinWave::calculateEigenvalues()
   }
 }
 
-bool isPositive(const results &i) { return i.weight > 0; }
-
-bool greaterThan(const results &a, const results &b) { return a.weight > b.weight; }
-
 void SpinWave::calculateWeights()
 {
   MatrixXcdRowMajor XX;
@@ -216,12 +212,18 @@ void SpinWave::calculateWeights()
   //
   // Reorder the XX's by the weights
   //
-  std::partition(AL.begin(), AL.end(), isPositive);
+  std::partition(AL.begin(), AL.end(), [](const results &i)
+                 {
+                   return i.weight > 0;
+                 });
 
   // If two eigenvalues are approx. zero, std::partition
   // may fail to separate positive and negative weights.
-  if (!isPositive(AL[M - 1]) || isPositive(AL[M]))
-    std::sort(AL.begin(), AL.end(), greaterThan);
+  if (AL[M - 1].weight < 0.0 || AL[M].weight > 0.0)
+    std::sort(AL.begin(), AL.end(), [](const results &a, const results &b)
+              {
+                return a.weight > b.weight;
+              });
 
   for (size_t L1 = 0; L1 < N; L1++)
   {

--- a/libSpinWaveGenie/src/Genie/SpinWaveBuilder.cpp
+++ b/libSpinWaveGenie/src/Genie/SpinWaveBuilder.cpp
@@ -18,17 +18,16 @@ SpinWaveBuilder::SpinWaveBuilder(Cell &cellIn) : cell(cellIn)
 
 void SpinWaveBuilder::updateCell(Cell &cellIn) { cell = cellIn; }
 
-struct lessThanUniquePtr
-{
-  bool operator()(const unique_ptr<Interaction> &a, const unique_ptr<Interaction> &b) { return *a < *b; }
-};
-
 void SpinWaveBuilder::addInteraction(std::unique_ptr<Interaction> in)
 {
   // cout << "cell check(Add_Interaction): " << cell.begin()->getName() << endl;
   // cout << "cell check(Add_Interaction): " << cell.begin()->getName() << endl;
   interactions.push_back(std::move(in));
-  std::sort(interactions.begin(), interactions.end(), lessThanUniquePtr());
+  std::sort(interactions.begin(), interactions.end(),
+            [](const std::unique_ptr<Interaction> &a, const std::unique_ptr<Interaction> &b)
+            {
+              return *a < *b;
+            });
 }
 
 void SpinWaveBuilder::updateInteraction(string name, double value)

--- a/libSpinWaveGenie/src/Interactions/ExchangeInteraction.cpp
+++ b/libSpinWaveGenie/src/Interactions/ExchangeInteraction.cpp
@@ -36,7 +36,13 @@ const string &ExchangeInteraction::getName() { return name; }
 
 void ExchangeInteraction::updateValue(double value_in) { value = value_in; }
 
-std::array<std::string, 2> ExchangeInteraction::sublattices() const { return {{sl_r, sl_s}}; }
+std::array<std::string, 2> ExchangeInteraction::sublattices() const
+{
+  if (sl_r < sl_s)
+    return {{sl_r, sl_s}};
+  else
+    return {{sl_s, sl_r}};
+}
 
 void ExchangeInteraction::calcConstantValues(Cell &cell)
 {

--- a/libSpinWaveGenie/src/Interactions/Interaction.cpp
+++ b/libSpinWaveGenie/src/Interactions/Interaction.cpp
@@ -18,14 +18,4 @@ bool Interaction::operator<(const Interaction &other) const
   return false;
 }
 
-bool Interaction::operator==(const Interaction &other) const
-{
-  auto sl1 = this->sublattices();
-  auto sl2 = other.sublattices();
-
-  if (sl1[0].compare(sl2[0]) == 0 && sl1[1].compare(sl2[1]) == 0)
-    return true;
-  else
-    return false;
-}
 }


### PR DESCRIPTION
The exchange interaction should always return the smaller (as defined by operator<) of the two sublattice strings . 

I removed operator== since it 
1. currently isn't being used.
2. since it only compares strings, it could be confusing.

Found a few places where a lambda expression is preferable to a functor.
