### PR TITLE
link spinwavegenie against libpthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ endif()
 
 find_package(Eigen3 REQUIRED)
 
+find_package(Threads)
 if(USE_THREADS)
   find_package(TBB)
 endif()

--- a/libSpinWaveGenie/CMakeLists.txt
+++ b/libSpinWaveGenie/CMakeLists.txt
@@ -50,7 +50,7 @@ set_property( TARGET SpinWaveGenie PROPERTY
 target_include_directories( SpinWaveGenie SYSTEM INTERFACE PUBLIC ${EIGEN3_INCLUDE_DIR} ${Boost_INCLUDE_DIR})
 target_include_directories( SpinWaveGenie PRIVATE src)
 target_include_directories( SpinWaveGenie SYSTEM PRIVATE ${TBB_INCLUDE_DIRS})
-target_link_libraries( SpinWaveGenie PRIVATE ${TBB_LIBRARIES})
+target_link_libraries( SpinWaveGenie PRIVATE ${TBB_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 if(BUILD_TESTING)
     add_subdirectory(test)


### PR DESCRIPTION
On RHEL 7 with GCC 4.8 I get the following error when running the FMChain example.

```
terminate called after throwing an instance of 'std::system_error'
  what():  Enable multithreading to use std::thread: Operation not permitted
Aborted
```

The fix includes adding `-lphread` to the linking arguments.
