### PR TITLE
Remove pimpl and simplify TwoDimensionalCut.

### DIFF
--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/TwoDimensionalCut.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/TwoDimensionalCut.h
@@ -9,12 +9,14 @@
 #ifndef __spin_wave_genie__TwoDimensionalCut__
 #define __spin_wave_genie__TwoDimensionalCut__
 
-#include "SpinWaveGenie/Memory.h"
 #include "SpinWaveGenie/Containers/ThreeVectors.h"
-#include "SpinWaveGenie/Plot/SpinWavePlot.h"
+
+#include <memory>
 
 namespace SpinWaveGenie
 {
+
+class SpinWavePlot;
 
 class TwoDimensionalCut
 {

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/TwoDimensionalCut.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/TwoDimensionalCut.h
@@ -19,22 +19,16 @@ namespace SpinWaveGenie
 class TwoDimensionalCut
 {
 public:
-  TwoDimensionalCut();
-  TwoDimensionalCut(const TwoDimensionalCut &other);
-  TwoDimensionalCut &operator=(const TwoDimensionalCut &other);
-  TwoDimensionalCut(TwoDimensionalCut &&other);
-  TwoDimensionalCut &operator=(TwoDimensionalCut &&other);
   void setFilename(std::string name);
   void setPoints(ThreeVectors<double> pos);
   void setEnergyPoints(double min, double max, size_t numberpoints);
   void setPlotObject(std::unique_ptr<SpinWavePlot> object);
   Eigen::MatrixXd getMatrix();
   void save();
-  ~TwoDimensionalCut();
-
 private:
-  class CutImpl;
-  std::unique_ptr<CutImpl> m_p;
+  std::string filename;
+  std::unique_ptr<SpinWaveGenie::SpinWavePlot> cut;
+  SpinWaveGenie::ThreeVectors<double> points;
 };
 }
 #endif /* defined(__spin_wave_genie__TwoDimensionalCut__) */

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/TwoDimensionalGaussian.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/TwoDimensionalGaussian.h
@@ -39,7 +39,6 @@ public:
   const Energies &getEnergies() override;
   void setEnergies(Energies energies) override;
   ~TwoDimensionResolutionFunction(){};
-
 private:
   std::vector<double> calculateIntegrand(std::deque<double> &x);
   Energies energies;

--- a/libSpinWaveGenie/src/Plot/TwoDimensionalCut.cpp
+++ b/libSpinWaveGenie/src/Plot/TwoDimensionalCut.cpp
@@ -7,21 +7,23 @@
 //
 #include <atomic>
 #include <fstream>
-#include <Eigen/Dense>
-#include "SpinWaveGenie/Plot/TwoDimensionalCut.h"
-#include "SpinWaveGenie/Plot/EnergyResolutionFunction.h"
-#include "SpinWaveGenie/Containers/Energies.h"
-#include "External/ezRateProgressBar.hpp"
 #include <thread>
 #ifdef _WIN32
 #include <Windows.h>
 #else
 #include <unistd.h>
 #endif
+
+#include <Eigen/Dense>
+
 #ifdef USE_THREADS
 #include "tbb/tbb.h"
-using namespace tbb;
 #endif
+
+#include "SpinWaveGenie/Plot/SpinWavePlot.h"
+#include "SpinWaveGenie/Plot/TwoDimensionalCut.h"
+#include "SpinWaveGenie/Containers/Energies.h"
+#include "External/ezRateProgressBar.hpp"
 
 namespace
 {


### PR DESCRIPTION
With lambda expressions available on all platforms we are able to eliminate the pimpl and simplify the implementation of TwoDimensionalCut.
