### PR TITLE
Fix compiler warnings from XCode 7.3

### DIFF
--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/IntegrateThetaPhi.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/IntegrateThetaPhi.h
@@ -24,7 +24,7 @@ public:
       : maximumEvaluations(maxEvals), r(0.0), tolerance(tol), resolutionFunction(std::move(object)){};
   IntegrateThetaPhi(const IntegrateThetaPhi &other)
       : maximumEvaluations(other.maximumEvaluations), r(0.0), tolerance(other.tolerance),
-        resolutionFunction(move(other.resolutionFunction->clone())){};
+        resolutionFunction(other.resolutionFunction->clone()){};
   std::unique_ptr<SpinWavePlot> clone() override;
   const Cell &getCell() const override;
   const Energies &getEnergies() override;

--- a/libSpinWaveGenie/src/Plot/AdaptiveSimpson.cpp
+++ b/libSpinWaveGenie/src/Plot/AdaptiveSimpson.cpp
@@ -250,7 +250,7 @@ AdaptiveSimpson::AdaptiveSimpson(const AdaptiveSimpson &other) : m_p(other.m_p->
 
 AdaptiveSimpson &AdaptiveSimpson::operator=(const AdaptiveSimpson &other)
 {
-  m_p = move(other.m_p->clone());
+  m_p = other.m_p->clone();
   return *this;
 }
 

--- a/libSpinWaveGenie/src/Plot/IntegrateAxes.cpp
+++ b/libSpinWaveGenie/src/Plot/IntegrateAxes.cpp
@@ -15,7 +15,7 @@ namespace SpinWaveGenie
 
 IntegrateAxes::IntegrateAxes(const IntegrateAxes &other) : kx(0.0), ky(0.0), kz(0.0)
 {
-  resolutionFunction = move(other.resolutionFunction->clone());
+  resolutionFunction = other.resolutionFunction->clone();
   this->maximumEvaluations = other.maximumEvaluations;
   this->tolerance = other.tolerance;
   this->integrationDirections = other.integrationDirections;

--- a/libSpinWaveGenie/src/Plot/IntegrateEnergy.cpp
+++ b/libSpinWaveGenie/src/Plot/IntegrateEnergy.cpp
@@ -16,7 +16,7 @@ namespace SpinWaveGenie
 
 IntegrateEnergy::IntegrateEnergy(const IntegrateEnergy &other) : kx(0.0), ky(0.0), kz(0.0)
 {
-  resolutionFunction = move(other.resolutionFunction->clone());
+  resolutionFunction = other.resolutionFunction->clone();
   this->centeredEnergies = other.centeredEnergies;
   this->delta = other.delta;
   this->tolerance = other.tolerance;


### PR DESCRIPTION
This fixes several compiler warnings appearing with the latest version of XCode, specifically places where `std::move` prevents copy elision.
