### PR TITLE
Use range-based for loops in neighbors class.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,13 @@ matrix:
       compiler: clang-3.6
       env: CLANG_SANITIZERS=true
     - os: osx
-      osx_image: xcode7.1
+      osx_image: xcode7.3
       compiler: clang
     - os: osx
-      osx_image: beta-xcode6.2
+      osx_image: xcode7.2
       compiler: clang
     - os: osx
-      osx_image: xcode7.1
+      osx_image: xcode7.2
       compiler: clang
       env: COVERALLS=true
     
@@ -45,7 +45,7 @@ before_install:
     then 
       sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test;
       sudo apt-get update -qq;
-      sudo apt-get install -qq cmake libboost-dev libboost-test-dev libeigen3-dev libtbb-dev libstdc++-4.9-dev clang-3.6;
+      sudo apt-get install -qq libboost-dev libboost-test-dev libeigen3-dev libtbb-dev libstdc++-4.9-dev clang-3.6;
       cmake --version;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,13 +43,10 @@ before_install:
     fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; 
     then 
-      sudo add-apt-repository --yes ppa:george-edison55/cmake-3.x;
       sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test;
       sudo apt-get update -qq;
-      sudo apt-get purge -qq cmake;
-      sudo apt-get install -qq cmake;
+      sudo apt-get install -qq cmake libboost-dev libboost-test-dev libeigen3-dev libtbb-dev libstdc++-4.9-dev clang-3.6;
       cmake --version;
-      sudo apt-get install -qq libboost-dev libboost-test-dev libeigen3-dev libtbb-dev libstdc++-4.9-dev clang-3.6;
     fi
 
 before_script:

--- a/libSpinWaveGenie/include/SpinWaveGenie/Genie/Neighbors.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Genie/Neighbors.h
@@ -20,7 +20,6 @@ class Cell;
 class Neighbors
 {
 public:
-  Neighbors() : numberNeighbors(0){};
   //! Returns whether of not neighbors have been calculated previously;
   //! \param
   bool empty();
@@ -36,13 +35,17 @@ public:
   //! Get variable \f$ \Gamma = \frac{1}{z_{rs}} \sum_{d} e^{-i \boldmath{k} \cdot \boldmath{d}} \f$
   //! described in J Phys. Condens. Matter 21 216001 (2009)
   //! \param K k vector used in spin wave calculation.
-  std::complex<double> getGamma(Vector3 K);
+  std::complex<double> getGamma(const Vector3 &K);
   typedef UniqueThreeVectors<double>::Iterator Iterator;
   typedef UniqueThreeVectors<double>::ConstIterator ConstIterator;
   //! \return Returns an Iterator pointing to the first element of the neighbor list
   Iterator begin();
   //! \return Returns an Iterator pointing to the final element of the neighbor list
   Iterator end();
+  //! \return Returns an Iterator pointing to the first element of the neighbor list
+  ConstIterator begin() const;
+  //! \return Returns an Iterator pointing to the final element of the neighbor list
+  ConstIterator end() const;
   //! \return Returns an ConstIterator pointing to the first element of the neighbor list
   ConstIterator cbegin() const;
   //! \return Returns an ConstIterator pointing to the final element of the neighbor list
@@ -51,7 +54,7 @@ public:
 
 private:
   UniqueThreeVectors<double> neighborList;
-  std::size_t numberNeighbors;
+  std::size_t numberNeighbors{0};
 };
 }
 #endif // __Neighbors_H__


### PR DESCRIPTION
There were several places in the neighbors class where range-based for loops provide cleaner and less verbose syntax.
