### PR TITLE
Pass Energies container by const reference.

### DIFF
--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/EnergyResolutionFunction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/EnergyResolutionFunction.h
@@ -28,12 +28,12 @@ public:
   EnergyResolution() = default;
   EnergyResolution(const EnergyResolution &other);
   EnergyResolution &operator=(EnergyResolution &other);
-  EnergyResolution(std::unique_ptr<OneDimensionalShapes> ResolutionFunctionIn, const T &SWIn, Energies energies);
+  EnergyResolution(std::unique_ptr<OneDimensionalShapes> ResolutionFunctionIn, const T &SWIn, const Energies &energies);
   std::vector<double> getCut(double kxIn, double kyIn, double kzIn) override;
   void setSpinWave(const T &SWIn);
   void setResolutionFunction(std::unique_ptr<OneDimensionalShapes> ResolutionFunctionIn);
   const Cell &getCell() const override;
-  void setEnergies(Energies energies) override;
+  void setEnergies(const Energies &energies) override;
   const Energies &getEnergies() override;
   std::unique_ptr<SpinWavePlot> clone() override;
 
@@ -49,7 +49,7 @@ template class EnergyResolution<SpinWave>;
 
 template <class T>
 EnergyResolution<T>::EnergyResolution(std::unique_ptr<OneDimensionalShapes> ResolutionFunctionIn, const T &SWIn,
-                                      Energies energiesIn)
+                                      const Energies &energiesIn)
 {
   // std::cout << "Creating Energy Resolution Function" << std::endl;
   this->energies = energiesIn;
@@ -120,7 +120,7 @@ template <class T> const Cell &EnergyResolution<T>::getCell() const { return SW.
 
 template <class T> const Energies &EnergyResolution<T>::getEnergies() { return energies; }
 
-template <class T> void EnergyResolution<T>::setEnergies(Energies energiesIn) { energies = energiesIn; }
+template <class T> void EnergyResolution<T>::setEnergies(const Energies &energiesIn) { energies = energiesIn; }
 
 template <class T> std::unique_ptr<SpinWavePlot> EnergyResolution<T>::clone()
 {

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/IntegrateAxes.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/IntegrateAxes.h
@@ -30,7 +30,7 @@ public:
   std::unique_ptr<SpinWavePlot> clone() override;
   const Cell &getCell() const override;
   const Energies &getEnergies() override;
-  void setEnergies(Energies energies) override;
+  void setEnergies(const Energies &energies) override;
 
 private:
   std::unique_ptr<SpinWavePlot> resolutionFunction;

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/IntegrateEnergy.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/IntegrateEnergy.h
@@ -29,7 +29,7 @@ public:
   std::unique_ptr<SpinWavePlot> clone() override;
   const Cell &getCell() const override;
   const Energies &getEnergies() override;
-  void setEnergies(Energies energies) override;
+  void setEnergies(const Energies &energies) override;
 
 private:
   std::vector<double> calculateIntegrand(std::deque<double> &x);

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/IntegrateThetaPhi.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/IntegrateThetaPhi.h
@@ -28,7 +28,7 @@ public:
   std::unique_ptr<SpinWavePlot> clone() override;
   const Cell &getCell() const override;
   const Energies &getEnergies() override;
-  void setEnergies(Energies energies) override;
+  void setEnergies(const Energies &energies) override;
   std::vector<double> getCut(double kx, double ky, double kz) override;
 
 private:

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/SpinWavePlot.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/SpinWavePlot.h
@@ -18,7 +18,7 @@ public:
   virtual std::unique_ptr<SpinWavePlot> clone() = 0;
   virtual const Cell &getCell() const = 0;
   virtual const Energies &getEnergies() = 0;
-  virtual void setEnergies(Energies energies) = 0;
+  virtual void setEnergies(const Energies &energies) = 0;
   virtual std::vector<double> getCut(double kx, double ky, double kz) = 0; // returns constant-Q cut
   virtual ~SpinWavePlot() = default;
 };

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/TwoDimensionalGaussian.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/TwoDimensionalGaussian.h
@@ -30,14 +30,15 @@ class TwoDimensionResolutionFunction : public SpinWavePlot
 {
 public:
   TwoDimensionResolutionFunction(){};
-  TwoDimensionResolutionFunction(TwoDimGaussian &info, const SpinWave &SW, Energies energies);
+  TwoDimensionResolutionFunction(const TwoDimGaussian &info, const SpinWave &SW, const Energies &energies);
   TwoDimensionResolutionFunction(const TwoDimensionResolutionFunction & /*other*/) = default;
   std::vector<double> getCut(double kxIn, double kyIn, double kzIn) override;
   void setTolerance(double tol, int maxEvals = 100000);
   std::unique_ptr<SpinWavePlot> clone() override;
   const Cell &getCell() const override;
   const Energies &getEnergies() override;
-  void setEnergies(Energies energies) override;
+  void setEnergies(const Energies &energies) override;
+
 private:
   std::vector<double> calculateIntegrand(std::deque<double> &x);
   Energies energies;

--- a/libSpinWaveGenie/src/Plot/IntegrateAxes.cpp
+++ b/libSpinWaveGenie/src/Plot/IntegrateAxes.cpp
@@ -99,7 +99,7 @@ const Cell &IntegrateAxes::getCell() const { return resolutionFunction->getCell(
 
 const Energies &IntegrateAxes::getEnergies() { return resolutionFunction->getEnergies(); }
 
-void IntegrateAxes::setEnergies(Energies energiesIn) { resolutionFunction->setEnergies(energiesIn); }
+void IntegrateAxes::setEnergies(const Energies &energiesIn) { resolutionFunction->setEnergies(energiesIn); }
 
 std::unique_ptr<SpinWavePlot> IntegrateAxes::clone() { return memory::make_unique<IntegrateAxes>(*this); }
 }

--- a/libSpinWaveGenie/src/Plot/IntegrateEnergy.cpp
+++ b/libSpinWaveGenie/src/Plot/IntegrateEnergy.cpp
@@ -66,7 +66,7 @@ const Cell &IntegrateEnergy::getCell() const { return resolutionFunction->getCel
 
 const Energies &IntegrateEnergy::getEnergies() { return centeredEnergies; }
 
-void IntegrateEnergy::setEnergies(Energies energiesIn) { centeredEnergies = energiesIn; }
+void IntegrateEnergy::setEnergies(const Energies &energiesIn) { centeredEnergies = energiesIn; }
 
 std::unique_ptr<SpinWavePlot> IntegrateEnergy::clone() { return memory::make_unique<IntegrateEnergy>(*this); }
 }

--- a/libSpinWaveGenie/src/Plot/IntegrateThetaPhi.cpp
+++ b/libSpinWaveGenie/src/Plot/IntegrateThetaPhi.cpp
@@ -24,7 +24,7 @@ const Cell &IntegrateThetaPhi::getCell() const { return resolutionFunction->getC
 
 const Energies &IntegrateThetaPhi::getEnergies() { return resolutionFunction->getEnergies(); }
 
-void IntegrateThetaPhi::setEnergies(Energies energiesIn) { resolutionFunction->setEnergies(energiesIn); }
+void IntegrateThetaPhi::setEnergies(const Energies &energiesIn) { resolutionFunction->setEnergies(energiesIn); }
 
 std::vector<double> IntegrateThetaPhi::calculateIntegrand(std::deque<double> &x)
 {

--- a/libSpinWaveGenie/src/Plot/TwoDimensionalGaussian.cpp
+++ b/libSpinWaveGenie/src/Plot/TwoDimensionalGaussian.cpp
@@ -20,15 +20,15 @@ using namespace std;
 
 namespace SpinWaveGenie
 {
-TwoDimensionResolutionFunction::TwoDimensionResolutionFunction(TwoDimGaussian &info, const SpinWave &SW,
-                                                               Energies energiesIn)
+TwoDimensionResolutionFunction::TwoDimensionResolutionFunction(const TwoDimGaussian &info, const SpinWave &SW,
+                                                               const Energies &energiesIn)
     : kx(0.0), ky(0.0), kz(0.0)
 {
   a = info.a;
   b = info.b;
   c = info.c;
-  info.direction.normalize();
   direction = info.direction;
+  direction.normalize();
   tolerance = info.tol;
   maximumEvaluations = 100;
   energies = energiesIn;
@@ -89,7 +89,7 @@ void TwoDimensionResolutionFunction::setTolerance(double toleranceIn, int maxEva
   maximumEvaluations = maxEvals;
 }
 
-void TwoDimensionResolutionFunction::setEnergies(Energies energiesIn) { energies = energiesIn; }
+void TwoDimensionResolutionFunction::setEnergies(const Energies &energiesIn) { energies = energiesIn; }
 
 std::unique_ptr<SpinWavePlot> TwoDimensionResolutionFunction::clone()
 {

--- a/libSpinWaveGenie/test/IntegrateEnergyTest.cpp
+++ b/libSpinWaveGenie/test/IntegrateEnergyTest.cpp
@@ -27,10 +27,7 @@ namespace SpinWaveGenie
         {
             return m_Energies;
         };
-        void setEnergies(Energies energies) override
-        {
-            m_Energies = energies;
-        };
+        void setEnergies(const Energies &energies) override { m_Energies = energies; };
         std::vector<double> getCut(double /*kx*/, double /*ky*/, double /*kz*/) override
         {
             double frequency = 10.0;

--- a/libSpinWaveGenie/test/IntegrateThetaPhiTest.cpp
+++ b/libSpinWaveGenie/test/IntegrateThetaPhiTest.cpp
@@ -28,10 +28,7 @@ namespace SpinWaveGenie
         {
             return m_Energies;
         };
-        void setEnergies(Energies energies) override
-        {
-            m_Energies = energies;
-        };
+        void setEnergies(const Energies &energies) override { m_Energies = energies; };
         std::vector<double> getCut(double /*kx*/, double /*ky*/, double /*kz*/) override { return std::vector<double>(1, 1.0); };
     private:
         SpinWaveGenie::Cell m_Cell;
@@ -74,10 +71,7 @@ public:
     {
         return m_Energies;
     };
-    void setEnergies(Energies energies) override
-    {
-        m_Energies = energies;
-    };
+    void setEnergies(const Energies &energies) override { m_Energies = energies; };
     std::vector<double> getCut(double kx, double ky, double kz) override
     {
         double r = sqrt(kx*kx+ky*ky+kz*kz);


### PR DESCRIPTION
Found a number of places where the energies container (essentially a std::vector) was being passed by value instead of const reference. This fixes these oversights.
