### PR TITLE
Scale energies by the number of atoms.

### DIFF
--- a/libSpinWaveGenie/include/SpinWaveGenie/Containers/Sublattice.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Containers/Sublattice.h
@@ -55,19 +55,22 @@ public:
   //! \param y y component of atomic position in Angstroms
   //! \param z z component of atomic position in Angstroms
   void addAtom(double x, double y, double z);
+  //! returns the number of atoms in this sublattice
+  //! \return number of atoms
+  std::size_t size() const { return positions.size(); }
   typedef UniqueThreeVectors<double>::Iterator Iterator;
   typedef UniqueThreeVectors<double>::ConstIterator ConstIterator;
-  //! returns an Iterator to the first atomic position;
+  //! returns an Iterator to the first atomic position
   Iterator begin() { return positions.begin(); }
-  //! returns an Iterator to the end of the vector;
+  //! returns an Iterator to the end of the vector
   Iterator end() { return positions.end(); }
-  //! returns an Iterator to the first atomic position;
+  //! returns an Iterator to the first atomic position
   ConstIterator begin() const { return positions.cbegin(); }
-  //! returns an Iterator to the end of the vector;
+  //! returns an Iterator to the end of the vector
   ConstIterator end() const { return positions.cend(); }
-  //! returns a ConstIterator to the first atomic position;
+  //! returns a ConstIterator to the first atomic position
   ConstIterator cbegin() const { return positions.cbegin(); }
-  //! returns a ConstIterator to the end of the vector;
+  //! returns a ConstIterator to the end of the vector
   ConstIterator cend() const { return positions.cend(); }
 
 private:

--- a/libSpinWaveGenie/include/SpinWaveGenie/Containers/ThreeVectors.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Containers/ThreeVectors.h
@@ -1,10 +1,11 @@
 #ifndef __ThreeVectors__
 #define __ThreeVectors__
 
-#include <vector>
 #include <boost/iterator/zip_iterator.hpp>
 #include <boost/tuple/tuple.hpp>
+#include <cassert>
 #include <iostream>
+#include <vector>
 
 //! Structure of Arrays used for storing vectors with three components.
 /*!

--- a/libSpinWaveGenie/include/SpinWaveGenie/Containers/ThreeVectors.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Containers/ThreeVectors.h
@@ -23,7 +23,7 @@ protected:
   typedef typename std::vector<T>::const_iterator ConstValueIterator;
 
 public:
-  bool empty();
+  bool empty() const;
   //! insert three elements x,y,z
   //! \param x zeroth element of type T
   //! \param y first element of type T
@@ -32,7 +32,7 @@ public:
   typedef boost::zip_iterator<boost::tuple<ValueIterator, ValueIterator, ValueIterator>> Iterator;
   typedef boost::zip_iterator<boost::tuple<ConstValueIterator, ConstValueIterator, ConstValueIterator>> ConstIterator;
   //! \return number of elements in the ThreeVector
-  size_t size();
+  size_t size() const;
   //! Clears all data stored in the ThreeVector.
   void clear();
   //! \return Returns an Iterator pointing to the first element
@@ -54,7 +54,7 @@ protected:
   std::vector<T> valuesZ;
 };
 
-template <typename T> bool ThreeVectors<T>::empty() { return valuesX.empty(); }
+template <typename T> bool ThreeVectors<T>::empty() const { return valuesX.empty(); }
 
 template <typename T> void ThreeVectors<T>::insert(T x, T y, T z)
 {
@@ -63,10 +63,10 @@ template <typename T> void ThreeVectors<T>::insert(T x, T y, T z)
   valuesZ.push_back(z);
 }
 
-template <typename T>
-
-size_t ThreeVectors<T>::size()
+template <typename T> size_t ThreeVectors<T>::size() const
 {
+  assert(valuesX.size() == valuesY.size());
+  assert(valuesX.size() == valuesZ.size());
   return valuesX.size();
 }
 

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteraction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteraction.h
@@ -15,8 +15,8 @@ namespace SpinWaveGenie
 class ExchangeInteraction : public Interaction
 {
 public:
-  ExchangeInteraction(std::string name, double value, const std::string &sl_r, const std::string &sl_s, double min,
-                      double max);
+  ExchangeInteraction(const std::string &name, double value, const std::string &sl_r, const std::string &sl_s,
+                      double min, double max);
   void updateInteraction(double value, const std::string &sl_r, const std::string &sl_s, double min, double max);
   void updateValue(double value_in) override;
   const std::string &getName() const override;

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteraction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteraction.h
@@ -15,7 +15,8 @@ namespace SpinWaveGenie
 class ExchangeInteraction : public Interaction
 {
 public:
-  ExchangeInteraction(std::string name, double value, std::string sl_r, std::string sl_s, double min, double max);
+  ExchangeInteraction(std::string name, double value, const std::string &sl_r, const std::string &sl_s, double min,
+                      double max);
   void updateInteraction(double value, const std::string &sl_r, const std::string &sl_s, double min, double max);
   void updateValue(double value_in) override;
   const std::string &getName() const override;

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteractionSameSublattice.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteractionSameSublattice.h
@@ -15,7 +15,8 @@ namespace SpinWaveGenie
 class ExchangeInteractionSameSublattice : public Interaction
 {
 public:
-  ExchangeInteractionSameSublattice(std::string name, double value, std::string sl_r, double min, double max);
+  ExchangeInteractionSameSublattice(const std::string &name, double value, const std::string &sl_r, double min,
+                                    double max);
   void updateInteraction(double value, const std::string &sl_r, double min, double max);
   void updateValue(double value_in) override;
   const std::string &getName() const override;

--- a/libSpinWaveGenie/src/Interactions/AnisotropyInteraction.cpp
+++ b/libSpinWaveGenie/src/Interactions/AnisotropyInteraction.cpp
@@ -80,7 +80,9 @@ void AnisotropyInteraction::calculateEnergy(const Cell &cell, double &energy)
   r = cell.getPosition(sl_r);
   double S = cell[r].getMoment();
   const Matrix3 &inv = cell[r].getInverseMatrix();
+  size_t numberOfAtoms = cell[r].size();
 
+  double temp{0.0};
   for (int i = 0; i < 3; i++)
   {
     for (int j = 0; j < 3; j++)
@@ -88,10 +90,11 @@ void AnisotropyInteraction::calculateEnergy(const Cell &cell, double &energy)
       // cout << i << " " << j << " " << directions(i,j) << endl;
       if (abs(directions(i, j)) > 1.0e-10)
       {
-        energy += value * directions(i, j) * S * S * inv(i, 2) * inv(j, 2);
+        temp += directions(i, j) * inv(i, 2) * inv(j, 2);
       }
     }
   }
+  energy += value * S * S * numberOfAtoms * temp;
 }
 
 void AnisotropyInteraction::calculateFirstOrderTerms(const Cell &cell, Eigen::VectorXcd &elements)

--- a/libSpinWaveGenie/src/Interactions/ExchangeInteraction.cpp
+++ b/libSpinWaveGenie/src/Interactions/ExchangeInteraction.cpp
@@ -1,7 +1,9 @@
-#include <iostream>
-#include "SpinWaveGenie/Genie/Neighbors.h"
 #include "SpinWaveGenie/Interactions/ExchangeInteraction.h"
+#include "SpinWaveGenie/Genie/Neighbors.h"
 #include "SpinWaveGenie/Memory.h"
+
+#include <cassert>
+#include <iostream>
 
 using namespace std;
 using namespace Eigen;
@@ -9,9 +11,9 @@ using namespace Eigen;
 namespace SpinWaveGenie
 {
 
-ExchangeInteraction::ExchangeInteraction(string name_in, double value_in, const string &sl_r_in, const string &sl_s_in,
-                                         double min_in, double max_in)
-    : name(std::move(name_in)), r(0), s(0), M(0)
+ExchangeInteraction::ExchangeInteraction(const string &name_in, double value_in, const string &sl_r_in,
+                                         const string &sl_s_in, double min_in, double max_in)
+    : name(name_in), r(0), s(0), M(0)
 {
   name = name_in;
   this->updateInteraction(value_in, sl_r_in, sl_s_in, min_in, max_in);

--- a/libSpinWaveGenie/src/Interactions/ExchangeInteraction.cpp
+++ b/libSpinWaveGenie/src/Interactions/ExchangeInteraction.cpp
@@ -9,9 +9,9 @@ using namespace Eigen;
 namespace SpinWaveGenie
 {
 
-ExchangeInteraction::ExchangeInteraction(string name_in, double value_in, string sl_r_in, string sl_s_in, double min_in,
-                                         double max_in)
-    : name(name_in), r(0), s(0), M(0)
+ExchangeInteraction::ExchangeInteraction(string name_in, double value_in, const string &sl_r_in, const string &sl_s_in,
+                                         double min_in, double max_in)
+    : name(std::move(name_in)), r(0), s(0), M(0)
 {
   name = name_in;
   this->updateInteraction(value_in, sl_r_in, sl_s_in, min_in, max_in);
@@ -86,11 +86,14 @@ void ExchangeInteraction::calculateEnergy(const Cell &cell, double &energy)
   double Sr = cell[r].getMoment();
   double Ss = cell[s].getMoment();
 
+  size_t numberOfAtoms = cell[r].size();
+  assert(numberOfAtoms == cell[s].size());
+
   Matrix3 Frs = cell[r].getRotationMatrix() * cell[s].getInverseMatrix();
 
   Matrix3 Fsr = cell[s].getRotationMatrix() * cell[r].getInverseMatrix();
 
-  energy -= 0.5 * value * z_rs * Sr * Ss * (Frs(2, 2) + Fsr(2, 2));
+  energy -= 0.5 * value * z_rs * Sr * Ss * numberOfAtoms * (Frs(2, 2) + Fsr(2, 2));
 }
 
 void ExchangeInteraction::calculateFirstOrderTerms(const Cell &cell, VectorXcd &elements)

--- a/libSpinWaveGenie/src/Interactions/ExchangeInteractionSameSublattice.cpp
+++ b/libSpinWaveGenie/src/Interactions/ExchangeInteractionSameSublattice.cpp
@@ -64,8 +64,8 @@ void ExchangeInteractionSameSublattice::calculateEnergy(const Cell &cell, double
   neighbors.findNeighbors(cell, sl_r, sl_r, min, max);
   double z_rs = static_cast<double>(neighbors.size());
   double Sr = cell[r].getMoment();
-
-  energy -= value * z_rs * Sr * Sr;
+  size_t numberOfAtoms = cell[r].size();
+  energy -= value * z_rs * numberOfAtoms * Sr * Sr;
 }
 
 void ExchangeInteractionSameSublattice::calculateFirstOrderTerms(const Cell & /*cell*/, VectorXcd & /*elements*/)

--- a/libSpinWaveGenie/src/Interactions/ExchangeInteractionSameSublattice.cpp
+++ b/libSpinWaveGenie/src/Interactions/ExchangeInteractionSameSublattice.cpp
@@ -1,7 +1,8 @@
-#include <iostream>
 #include "SpinWaveGenie/Interactions/ExchangeInteractionSameSublattice.h"
 #include "SpinWaveGenie/Genie/Neighbors.h"
 #include "SpinWaveGenie/Memory.h"
+#include <cassert>
+#include <iostream>
 
 using namespace std;
 using namespace Eigen;
@@ -9,9 +10,10 @@ using namespace Eigen;
 namespace SpinWaveGenie
 {
 
-ExchangeInteractionSameSublattice::ExchangeInteractionSameSublattice(string name_in, double value_in, string sl_r_in,
-                                                                     double min_in, double max_in)
-    : name(std::move(name_in)), r(0), s(0), M(0)
+ExchangeInteractionSameSublattice::ExchangeInteractionSameSublattice(const string &name_in, double value_in,
+                                                                     const string &sl_r_in, double min_in,
+                                                                     double max_in)
+    : name(name_in), r(0), s(0), M(0)
 {
   this->updateInteraction(value_in, sl_r_in, min_in, max_in);
 }

--- a/libSpinWaveGenie/src/Interactions/MagneticFieldInteraction.cpp
+++ b/libSpinWaveGenie/src/Interactions/MagneticFieldInteraction.cpp
@@ -45,14 +45,17 @@ void MagneticFieldInteraction::calculateEnergy(const Cell &cell, double &energy)
   r = cell.getPosition(sl_r);
   double S = cell[r].getMoment();
   const Matrix3 &inv = cell[r].getInverseMatrix();
+  size_t numberOfAtoms = cell[r].size();
 
+  double temp{0.0};
   for (int i = 0; i < 3; i++)
   {
     if (std::abs(directions(i)) > 1.0e-10)
     {
-      energy -= value * S * directions(i) * inv(i, 2);
+      temp -= directions(i) * inv(i, 2);
     }
   }
+  energy += value * S * numberOfAtoms * temp;
 }
 
 void MagneticFieldInteraction::calculateFirstOrderTerms(const Cell &cell, Eigen::VectorXcd &elements)

--- a/libSpinWaveGenie/test/InteractionsContainerTest.cpp
+++ b/libSpinWaveGenie/test/InteractionsContainerTest.cpp
@@ -75,7 +75,6 @@ BOOST_AUTO_TEST_CASE(PrintList)
   InteractionsContainer interactions = getInteractions();
   std::stringstream teststream;
   std::string header;
-  std::cout << interactions;
   teststream << interactions;
   std::getline(teststream, header, '\n');
   BOOST_CHECK_EQUAL("  Name  sl1   sl2", header);

--- a/libSpinWaveGenie/test/InteractionsContainerTest.cpp
+++ b/libSpinWaveGenie/test/InteractionsContainerTest.cpp
@@ -75,6 +75,7 @@ BOOST_AUTO_TEST_CASE(PrintList)
   InteractionsContainer interactions = getInteractions();
   std::stringstream teststream;
   std::string header;
+  std::cout << interactions;
   teststream << interactions;
   std::getline(teststream, header, '\n');
   BOOST_CHECK_EQUAL("  Name  sl1   sl2", header);

--- a/libSpinWaveGenie/test/SublatticeTest.cpp
+++ b/libSpinWaveGenie/test/SublatticeTest.cpp
@@ -14,6 +14,7 @@ BOOST_AUTO_TEST_CASE( ConstructorsTest )
 
     BOOST_CHECK_EQUAL(test.getName(),"");
     BOOST_CHECK_EQUAL(test.getType(),"None");
+    BOOST_CHECK_EQUAL(test.size(), 0);
     BOOST_CHECK_SMALL(test.getMoment(),1.0e-8);
     BOOST_CHECK_SMALL(test.getTheta(),1.0e-8);
     BOOST_CHECK_SMALL(test.getPhi(),1.0e-8);
@@ -48,7 +49,8 @@ BOOST_AUTO_TEST_CASE( AtomsTest )
     Sublattice test;
     test.addAtom(0.0,0.0,0.0);
     test.addAtom(0.5,0.5,0.5);
-    
+    BOOST_CHECK_EQUAL(test.size(), 2);
+
     Vector3 atom0(0.0,0.0,0.0);
     bool FoundAtom0 = false;
     Vector3 atom1(0.25,0.25,0.25);


### PR DESCRIPTION
The classical energy per cell should scale by the number of atoms, not just the number of sublattices.
