### PR TITLE
Set visibility hidden and generate export headers.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ branches:
 configuration: Release
 
 environment:
-  PATH: "C:/projects/ThirdPartyVC140/lib;%PATH%"
+  PATH: "C:/projects/ThirdPartyVC140/lib;C:\projects\spinwavegenie\build\libSpinWaveGenie\Release\;%PATH%"
   matrix:
     - PYTHON_DIR: "Python27-x64"
       CACHE_FILENAME: "AppveyorPython27-x64.cmake"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ branches:
 configuration: Release
 
 environment:
-  PATH: "C:/projects/ThirdPartyVC140/lib;C:\projects\spinwavegenie\build\libSpinWaveGenie\Release\;%PATH%"
+  PATH: "C:/projects/ThirdPartyVC140/lib;C:/projects/spinwavegenie/build/libSpinWaveGenie/Release;%PATH%"
   matrix:
     - PYTHON_DIR: "Python27-x64"
       CACHE_FILENAME: "AppveyorPython27-x64.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,10 @@ endif()
 
 find_package(Boost REQUIRED COMPONENTS unit_test_framework)
 
+if(MSVC)
+  add_compile_options(/wd4251)
+endif()
+
 if(WIN32)
     add_definitions( -DBOOST_ALL_NO_LIB
                      -DBOOST_ALL_DYN_LINK

--- a/libSpinWaveGenie/CMakeLists.txt
+++ b/libSpinWaveGenie/CMakeLists.txt
@@ -32,21 +32,20 @@ if (COVERALLS)
         )
 endif()
 
-if(WIN32)
-  #include(GenerateExportHeader)
-  #add_compiler_export_flags()
-  add_library(SpinWaveGenie STATIC ${LIBRARY_SRCS} ${LIBRARY_HDRS})
-  #generate_export_header(SpinWaveGenie)
-else()
-  add_library(SpinWaveGenie SHARED ${LIBRARY_SRCS} ${LIBRARY_HDRS})
-endif()
+include(GenerateExportHeader)
+add_library(SpinWaveGenie SHARED ${LIBRARY_SRCS} ${LIBRARY_HDRS})
+generate_export_header(SpinWaveGenie EXPORT_FILE_NAME SpinWaveGenie/Export.h)
+
 #We need need the header files both to build SpinWaveGenie and for the interface.
-target_include_directories( SpinWaveGenie PRIVATE include )               
+target_include_directories( SpinWaveGenie PRIVATE include ${CMAKE_CURRENT_BINARY_DIR})               
 set_property( TARGET SpinWaveGenie PROPERTY
               INTERFACE_INCLUDE_DIRECTORIES
-              "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+              "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_BINARY_DIR}>"
               "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>"
 )
+set_property( TARGET SpinWaveGenie PROPERTY CXX_VISIBILITY_PRESET hidden)
+set_property( TARGET SpinWaveGenie PROPERTY VISIBILITY_INLINES_HIDDEN 1)
+
 target_include_directories( SpinWaveGenie SYSTEM INTERFACE PUBLIC ${EIGEN3_INCLUDE_DIR} ${Boost_INCLUDE_DIR} )
 target_include_directories( SpinWaveGenie PRIVATE src)
 target_include_directories( SpinWaveGenie SYSTEM PRIVATE ${TBB_INCLUDE_DIRS})
@@ -59,6 +58,7 @@ endif (BUILD_TESTING)
 include(GNUInstallDirs)
 
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/SpinWaveGenie/Export.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/SpinWaveGenie )
 install(TARGETS SpinWaveGenie EXPORT SpinWaveGenieTargets 
                               ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                               LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libSpinWaveGenie/include/SpinWaveGenie/Containers/Cell.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Containers/Cell.h
@@ -2,9 +2,10 @@
 #ifndef __Cell_H__
 #define __Cell_H__
 
-#include <vector>
-#include <string>
 #include "SpinWaveGenie/Containers/Sublattice.h"
+#include "SpinWaveGenie/Export.h"
+#include <string>
+#include <vector>
 
 namespace Eigen
 {
@@ -19,7 +20,7 @@ namespace SpinWaveGenie
 The Cell class stores the basis vectors and all sublattices in the unit cell.
 Atomic positions are inserted as a fraction of the basis vectors and converted to Angstroms.
 */
-class Cell
+class SPINWAVEGENIE_EXPORT Cell
 {
 public:
   //! Set basis vectors from parameters a, b, c, \f$\alpha,\: \beta,\: \gamma \f$.

--- a/libSpinWaveGenie/include/SpinWaveGenie/Containers/Energies.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Containers/Energies.h
@@ -9,6 +9,7 @@
 #ifndef __spin_wave_genie__Energies__
 #define __spin_wave_genie__Energies__
 
+#include "SpinWaveGenie/Export.h"
 #include <iostream>
 #include <vector>
 
@@ -22,7 +23,7 @@ namespace SpinWaveGenie
     and upper bound of the index.
  */
 
-class Energies
+class SPINWAVEGENIE_EXPORT Energies
 {
 public:
   //! Default constructor
@@ -69,8 +70,8 @@ public:
   ConstIterator cbegin() const { return energies.cbegin(); }
   //! \return Returns a ConstIterator pointing to the end of the container.
   ConstIterator cend() const { return energies.cend(); }
-  friend std::ostream &operator<<(std::ostream &output, const Energies &n);
-  
+  friend SPINWAVEGENIE_EXPORT std::ostream &operator<<(std::ostream &output, const Energies &n);
+
 private:
   std::vector<double> energies;
 };

--- a/libSpinWaveGenie/include/SpinWaveGenie/Containers/HKLDirections.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Containers/HKLDirections.h
@@ -9,6 +9,7 @@
 #ifndef __spin_wave_genie__HKLDirection__
 #define __spin_wave_genie__HKLDirection__
 
+#include "SpinWaveGenie/Export.h"
 #include <iostream>
 #include <vector>
 
@@ -39,7 +40,7 @@ struct Axis
  Axes DO NOT need to be orthogonal.
  */
 
-class HKLDirections
+class SPINWAVEGENIE_EXPORT HKLDirections
 {
 public:
   //! Add integration direction to container.

--- a/libSpinWaveGenie/include/SpinWaveGenie/Containers/PointsAlongLine.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Containers/PointsAlongLine.h
@@ -1,8 +1,9 @@
 #ifndef __PointsAlongLine__
 #define __PointsAlongLine__
 
-#include <iostream>
 #include "SpinWaveGenie/Containers/ThreeVectors.h"
+#include "SpinWaveGenie/Export.h"
+#include <iostream>
 
 namespace SpinWaveGenie
 {
@@ -13,7 +14,7 @@ namespace SpinWaveGenie
  The result is stored in a ThreeVectors<double> container.
  */
 
-class PointsAlongLine
+class SPINWAVEGENIE_EXPORT PointsAlongLine
 {
 public:
   //! Set starting point of line. (inclusive)

--- a/libSpinWaveGenie/include/SpinWaveGenie/Containers/Results.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Containers/Results.h
@@ -9,6 +9,7 @@
 #ifndef __spin_wave_genie__Results__
 #define __spin_wave_genie__Results__
 
+#include "SpinWaveGenie/Export.h"
 #include <iostream>
 #include <vector>
 
@@ -38,7 +39,7 @@ struct Point
  significant intensity are discarded.
  */
 
-class Results
+class SPINWAVEGENIE_EXPORT Results
 {
 public:
   //! Insert Point struct into container.
@@ -68,8 +69,8 @@ public:
   ConstIterator cbegin() const { return results.cbegin(); }
   //! \return Returns an ConstIterator pointing to the end of the container.
   ConstIterator cend() const { return results.cend(); }
-  friend std::ostream &operator<<(std::ostream &output, const Results &n);
-  
+  friend SPINWAVEGENIE_EXPORT std::ostream &operator<<(std::ostream &output, const Results &n);
+
 private:
   std::vector<Point> results;
 };

--- a/libSpinWaveGenie/include/SpinWaveGenie/Containers/Sublattice.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Containers/Sublattice.h
@@ -1,10 +1,11 @@
 #ifndef __Sublattice_H__
 #define __Sublattice_H__
 
-#include <vector>
-#include <string>
 #include "SpinWaveGenie/Containers/Matrices.h"
 #include "SpinWaveGenie/Containers/UniqueThreeVectors.h"
+#include "SpinWaveGenie/Export.h"
+#include <string>
+#include <vector>
 
 namespace SpinWaveGenie
 {
@@ -15,7 +16,7 @@ namespace SpinWaveGenie
  the atomic positions of a particular sublattice. In addition, it calculates rotation
  and inverse rotation matrices.
  */
-class Sublattice
+class SPINWAVEGENIE_EXPORT Sublattice
 {
 public:
   //! Default constructor

--- a/libSpinWaveGenie/include/SpinWaveGenie/Containers/ThreeVectors.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Containers/ThreeVectors.h
@@ -1,7 +1,6 @@
 #ifndef __ThreeVectors__
 #define __ThreeVectors__
 
-#include "SpinWaveGenie/Export.h"
 #include <array>
 #include <cassert>
 #include <iostream>
@@ -17,7 +16,7 @@
 namespace SpinWaveGenie
 {
 
-template <typename T> class SPINWAVEGENIE_EXPORT ThreeVectors
+template <typename T> class ThreeVectors
 {
 
 public:

--- a/libSpinWaveGenie/include/SpinWaveGenie/Containers/ThreeVectors.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Containers/ThreeVectors.h
@@ -1,6 +1,7 @@
 #ifndef __ThreeVectors__
 #define __ThreeVectors__
 
+#include "SpinWaveGenie/Export.h"
 #include <array>
 #include <cassert>
 #include <iostream>
@@ -16,7 +17,7 @@
 namespace SpinWaveGenie
 {
 
-template <typename T> class ThreeVectors
+template <typename T> class SPINWAVEGENIE_EXPORT ThreeVectors
 {
 
 public:

--- a/libSpinWaveGenie/include/SpinWaveGenie/Containers/UniqueThreeVectors.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Containers/UniqueThreeVectors.h
@@ -9,9 +9,10 @@
 #ifndef __positions__UniqueThreeVectors__
 #define __positions__UniqueThreeVectors__
 
+#include "SpinWaveGenie/Containers/ThreeVectors.h"
+#include "SpinWaveGenie/Export.h"
 #include <complex>
 #include <iostream>
-#include "SpinWaveGenie/Containers/ThreeVectors.h"
 
 namespace SpinWaveGenie
 {
@@ -24,7 +25,7 @@ namespace SpinWaveGenie
  unique vectors are stored.
  */
 
-template <typename T> class UniqueThreeVectors : public ThreeVectors<T>
+template <typename T> class SPINWAVEGENIE_EXPORT UniqueThreeVectors : public ThreeVectors<T>
 {
 public:
   //!

--- a/libSpinWaveGenie/include/SpinWaveGenie/Containers/UniqueThreeVectors.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Containers/UniqueThreeVectors.h
@@ -10,7 +10,6 @@
 #define __positions__UniqueThreeVectors__
 
 #include "SpinWaveGenie/Containers/ThreeVectors.h"
-#include "SpinWaveGenie/Export.h"
 #include <complex>
 #include <iostream>
 
@@ -25,7 +24,7 @@ namespace SpinWaveGenie
  unique vectors are stored.
  */
 
-template <typename T> class SPINWAVEGENIE_EXPORT UniqueThreeVectors : public ThreeVectors<T>
+template <typename T> class UniqueThreeVectors : public ThreeVectors<T>
 {
 public:
   //!

--- a/libSpinWaveGenie/include/SpinWaveGenie/Genie/MagneticFormFactor.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Genie/MagneticFormFactor.h
@@ -9,6 +9,7 @@
 #ifndef __MagneticFormFactor__
 #define __MagneticFormFactor__
 
+#include "SpinWaveGenie/Export.h"
 #include <iostream>
 #include <unordered_map>
 #include <vector>
@@ -30,7 +31,7 @@ href="http://www.ill.eu/index.php?eID=tx_nawsecuredl&u=0&file=fileadmin/users_fi
 ILL Neutron Data Booklet </a>
  */
 
-class MagneticFormFactor
+class SPINWAVEGENIE_EXPORT MagneticFormFactor
 {
 public:
   //! Default Constructor.

--- a/libSpinWaveGenie/include/SpinWaveGenie/Genie/Neighbors.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Genie/Neighbors.h
@@ -1,9 +1,10 @@
 #ifndef __Neighbors_H__
 #define __Neighbors_H__
 
-#include <ostream>
 #include "SpinWaveGenie/Containers/Matrices.h"
 #include "SpinWaveGenie/Containers/UniqueThreeVectors.h"
+#include "SpinWaveGenie/Export.h"
+#include <ostream>
 
 namespace SpinWaveGenie
 {
@@ -17,7 +18,7 @@ class Cell;
  sublattices they belong to and the minimum and maximum distance they are separated by.
  */
 
-class Neighbors
+class SPINWAVEGENIE_EXPORT Neighbors
 {
 public:
   //! Returns whether of not neighbors have been calculated previously;
@@ -50,7 +51,7 @@ public:
   ConstIterator cbegin() const { return neighborList.cbegin(); }
   //! \return Returns an ConstIterator pointing to the final element of the neighbor list
   ConstIterator cend() const { return neighborList.cend(); }
-  friend std::ostream &operator<<(std::ostream &output, const Neighbors &n);
+  friend SPINWAVEGENIE_EXPORT std::ostream &operator<<(std::ostream &output, const Neighbors &n);
 
 private:
   UniqueThreeVectors<double> neighborList;

--- a/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWave.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWave.h
@@ -5,6 +5,7 @@
 #include "SpinWaveGenie/Containers/Matrices.h"
 #include "SpinWaveGenie/Containers/Results.h"
 #include "SpinWaveGenie/Containers/Results.h"
+#include "SpinWaveGenie/Export.h"
 #include "SpinWaveGenie/Genie/MagneticFormFactor.h"
 #include "SpinWaveGenie/Genie/Neighbors.h"
 #include "SpinWaveGenie/Interactions/Interaction.h"
@@ -32,7 +33,7 @@ struct results
 The SpinWave Class stores the "L" matrix and calculates
 the spin wave frequencies and intensities.
 */
-class SpinWave
+class SPINWAVEGENIE_EXPORT SpinWave
 {
 public:
   //! Use SpinWaveBuilder to generate SpinWave instance

--- a/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWaveBuilder.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Genie/SpinWaveBuilder.h
@@ -1,6 +1,7 @@
 #ifndef __SpinWaveBuilder_H__
 #define __SpinWaveBuilder_H__ 1
 
+#include "SpinWaveGenie/Export.h"
 #include "SpinWaveGenie/Genie/SpinWave.h"
 #include "SpinWaveGenie/Interactions/Interaction.h"
 #include "SpinWaveGenie/Interactions/InteractionsContainer.h"
@@ -11,7 +12,7 @@
 namespace SpinWaveGenie
 {
 
-class SpinWaveBuilder
+class SPINWAVEGENIE_EXPORT SpinWaveBuilder
 {
 public:
   //! Default Constructor

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/AnisotropyInteraction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/AnisotropyInteraction.h
@@ -9,13 +9,14 @@
 #ifndef __spin_wave_genie__AnisotropyInteraction__
 #define __spin_wave_genie__AnisotropyInteraction__
 
-#include <iostream>
+#include "SpinWaveGenie/Export.h"
 #include "SpinWaveGenie/Interactions/Interaction.h"
+#include <iostream>
 
 namespace SpinWaveGenie
 {
 
-class AnisotropyInteraction : public Interaction
+class SPINWAVEGENIE_EXPORT AnisotropyInteraction : public Interaction
 {
 public:
   //!

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/DM_Y_Interaction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/DM_Y_Interaction.h
@@ -1,17 +1,18 @@
 #ifndef __DMY_Interaction_H__
 #define __DMY_Interaction_H__ 1
 
+#include "SpinWaveGenie/Containers/Cell.h"
+#include "SpinWaveGenie/Export.h"
+#include "SpinWaveGenie/Genie/Neighbors.h"
+#include "SpinWaveGenie/Interactions/Interaction.h"
+#include <Eigen/Dense>
 #include <string>
 #include <vector>
-#include <Eigen/Dense>
-#include "SpinWaveGenie/Containers/Cell.h"
-#include "SpinWaveGenie/Interactions/Interaction.h"
-#include "SpinWaveGenie/Genie/Neighbors.h"
 
 namespace SpinWaveGenie
 {
 
-class DM_Y_Interaction : public Interaction
+class SPINWAVEGENIE_EXPORT DM_Y_Interaction : public Interaction
 {
 public:
   DM_Y_Interaction(std::string name, double value_in, std::string sl_r_in, std::string sl_s_in, double min_in,

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/DM_Z_Interaction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/DM_Z_Interaction.h
@@ -1,17 +1,18 @@
 #ifndef __DMZ_Interaction_H__
 #define __DMZ_Interaction_H__ 1
 
+#include "SpinWaveGenie/Containers/Cell.h"
+#include "SpinWaveGenie/Export.h"
+#include "SpinWaveGenie/Genie/Neighbors.h"
+#include "SpinWaveGenie/Interactions/Interaction.h"
+#include <Eigen/Dense>
 #include <string>
 #include <vector>
-#include <Eigen/Dense>
-#include "SpinWaveGenie/Containers/Cell.h"
-#include "SpinWaveGenie/Interactions/Interaction.h"
-#include "SpinWaveGenie/Genie/Neighbors.h"
 
 namespace SpinWaveGenie
 {
 
-class DM_Z_Interaction : public Interaction
+class SPINWAVEGENIE_EXPORT DM_Z_Interaction : public Interaction
 {
 public:
   DM_Z_Interaction(std::string name, double value_in, std::string sl_r_in, std::string sl_s_in, double min_in,

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteraction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteraction.h
@@ -1,18 +1,19 @@
 #ifndef __ExchangeInteraction_H__
 #define __ExchangeInteraction_H__
 
+#include "SpinWaveGenie/Containers/Cell.h"
+#include "SpinWaveGenie/Containers/Matrices.h"
+#include "SpinWaveGenie/Export.h"
+#include "SpinWaveGenie/Genie/Neighbors.h"
+#include "SpinWaveGenie/Interactions/Interaction.h"
+#include <Eigen/Dense>
 #include <string>
 #include <vector>
-#include <Eigen/Dense>
-#include "SpinWaveGenie/Containers/Cell.h"
-#include "SpinWaveGenie/Interactions/Interaction.h"
-#include "SpinWaveGenie/Containers/Matrices.h"
-#include "SpinWaveGenie/Genie/Neighbors.h"
 
 namespace SpinWaveGenie
 {
 
-class ExchangeInteraction : public Interaction
+class SPINWAVEGENIE_EXPORT ExchangeInteraction : public Interaction
 {
 public:
   ExchangeInteraction(const std::string &name, double value, const std::string &sl_r, const std::string &sl_s,

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteractionSameSublattice.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/ExchangeInteractionSameSublattice.h
@@ -1,18 +1,19 @@
 #ifndef __ExchangeInteractionSameSublattice_H__
 #define __ExchangeInteractionSameSublattice_H__
 
+#include "SpinWaveGenie/Containers/Cell.h"
+#include "SpinWaveGenie/Containers/Matrices.h"
+#include "SpinWaveGenie/Export.h"
+#include "SpinWaveGenie/Genie/Neighbors.h"
+#include "SpinWaveGenie/Interactions/Interaction.h"
+#include <Eigen/Dense>
 #include <string>
 #include <vector>
-#include <Eigen/Dense>
-#include "SpinWaveGenie/Containers/Cell.h"
-#include "SpinWaveGenie/Interactions/Interaction.h"
-#include "SpinWaveGenie/Containers/Matrices.h"
-#include "SpinWaveGenie/Genie/Neighbors.h"
 
 namespace SpinWaveGenie
 {
 
-class ExchangeInteractionSameSublattice : public Interaction
+class SPINWAVEGENIE_EXPORT ExchangeInteractionSameSublattice : public Interaction
 {
 public:
   ExchangeInteractionSameSublattice(const std::string &name, double value, const std::string &sl_r, double min,

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/Interaction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/Interaction.h
@@ -1,11 +1,12 @@
 #ifndef __Interaction_H__
 #define __Interaction_H__ 1
 
+#include "SpinWaveGenie/Containers/Cell.h"
+#include "SpinWaveGenie/Export.h"
+#include <Eigen/Dense>
+#include <array>
 #include <memory>
 #include <string>
-#include <array>
-#include <Eigen/Dense>
-#include "SpinWaveGenie/Containers/Cell.h"
 
 //! Base class for all classes describing magnetic interactions
 
@@ -14,7 +15,7 @@ namespace SpinWaveGenie
 
 class Neighbors;
 
-class Interaction
+class SPINWAVEGENIE_EXPORT Interaction
 {
 public:
   virtual std::array<std::string, 2> sublattices() const = 0;

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/InteractionFactory.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/InteractionFactory.h
@@ -9,17 +9,17 @@
 #ifndef __spin_wave_genie__InteractionFactory__
 #define __spin_wave_genie__InteractionFactory__
 
-#include <iostream>
-#include "SpinWaveGenie/Memory.h"
-#include <string>
-
 #include "SpinWaveGenie/Containers/Matrices.h"
+#include "SpinWaveGenie/Export.h"
 #include "SpinWaveGenie/Interactions/Interaction.h"
+#include "SpinWaveGenie/Memory.h"
+#include <iostream>
+#include <string>
 
 namespace SpinWaveGenie
 {
 
-class InteractionFactory
+class SPINWAVEGENIE_EXPORT InteractionFactory
 {
 public:
   std::unique_ptr<Interaction> getExchange(const std::string &name, double value, const std::string &sl_r,

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/InteractionsContainer.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/InteractionsContainer.h
@@ -1,8 +1,8 @@
 #ifndef __SpinWaveGenie__InteractionsContainer__
 #define __SpinWaveGenie__InteractionsContainer__
 
+#include "SpinWaveGenie/Export.h"
 #include "SpinWaveGenie/Interactions/Interaction.h"
-
 #include <boost/iterator/indirect_iterator.hpp>
 
 #include <iostream>
@@ -17,7 +17,7 @@ namespace SpinWaveGenie
  objects must be constructed on the heap and stored as pointers. This class
  is designed to hide many of these complications from other classes.
  */
-class InteractionsContainer
+class SPINWAVEGENIE_EXPORT InteractionsContainer
 {
 public:
   InteractionsContainer() = default;
@@ -50,7 +50,7 @@ public:
   //! \return Returns a ConstIterator pointing to the end of the container.
   ConstIterator cend() const { return container.cend(); }
   //! Helper function for printing the contents of an InteractionsContainer.
-  friend std::ostream &operator<<(std::ostream &output, const InteractionsContainer &n);
+  friend SPINWAVEGENIE_EXPORT std::ostream &operator<<(std::ostream &output, const InteractionsContainer &n);
 
 private:
   std::vector<std::unique_ptr<Interaction>> container;

--- a/libSpinWaveGenie/include/SpinWaveGenie/Interactions/MagneticFieldInteraction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Interactions/MagneticFieldInteraction.h
@@ -9,13 +9,14 @@
 #ifndef __spin_wave_genie__MagneticFieldInteraction__
 #define __spin_wave_genie__MagneticFieldInteraction__
 
-#include <iostream>
+#include "SpinWaveGenie/Export.h"
 #include "SpinWaveGenie/Interactions/Interaction.h"
+#include <iostream>
 
 namespace SpinWaveGenie
 {
 
-class MagneticFieldInteraction : public Interaction
+class SPINWAVEGENIE_EXPORT MagneticFieldInteraction : public Interaction
 {
 public:
   //!

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/AdaptiveSimpson.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/AdaptiveSimpson.h
@@ -1,12 +1,13 @@
 #ifndef __AdaptiveSimpson__
 #define __AdaptiveSimpson__
 
-#include <vector>
-#include <functional>
-#include <deque>
+#include "SpinWaveGenie/Export.h"
 #include "SpinWaveGenie/Memory.h"
+#include <deque>
+#include <functional>
+#include <vector>
 
-class AdaptiveSimpson
+class SPINWAVEGENIE_EXPORT AdaptiveSimpson
 //! Numerical Integration using the Adaptive Simpson's method.
 /*!
  This class vector quantities multiple dimensions.

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/EnergyResolutionFunction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/EnergyResolutionFunction.h
@@ -9,20 +9,21 @@
 #ifndef __EnergyResolutionFunction__
 #define __EnergyResolutionFunction__
 
-#include <iostream>
-#include "SpinWaveGenie/Memory.h"
-#include <algorithm>
-#include "SpinWaveGenie/Genie/SpinWave.h"
-#include "SpinWaveGenie/Plot/SpinWavePlot.h"
 #include "SpinWaveGenie/Containers/Cell.h"
-#include "SpinWaveGenie/Plot/OneDimensionalShapes.h"
 #include "SpinWaveGenie/Containers/Energies.h"
 #include "SpinWaveGenie/Containers/Results.h"
+#include "SpinWaveGenie/Export.h"
+#include "SpinWaveGenie/Genie/SpinWave.h"
+#include "SpinWaveGenie/Memory.h"
+#include "SpinWaveGenie/Plot/OneDimensionalShapes.h"
+#include "SpinWaveGenie/Plot/SpinWavePlot.h"
+#include <algorithm>
+#include <iostream>
 
 namespace SpinWaveGenie
 {
 
-template <class T> class EnergyResolution : public SpinWavePlot
+template <class T> class SPINWAVEGENIE_EXPORT EnergyResolution : public SpinWavePlot
 {
 public:
   EnergyResolution() = default;

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/EnergyResolutionFunction.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/EnergyResolutionFunction.h
@@ -12,7 +12,6 @@
 #include "SpinWaveGenie/Containers/Cell.h"
 #include "SpinWaveGenie/Containers/Energies.h"
 #include "SpinWaveGenie/Containers/Results.h"
-#include "SpinWaveGenie/Export.h"
 #include "SpinWaveGenie/Genie/SpinWave.h"
 #include "SpinWaveGenie/Memory.h"
 #include "SpinWaveGenie/Plot/OneDimensionalShapes.h"
@@ -23,7 +22,7 @@
 namespace SpinWaveGenie
 {
 
-template <class T> class SPINWAVEGENIE_EXPORT EnergyResolution : public SpinWavePlot
+template <class T> class EnergyResolution : public SpinWavePlot
 {
 public:
   EnergyResolution() = default;

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/IntegrateAxes.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/IntegrateAxes.h
@@ -9,18 +9,19 @@
 #ifndef __IntegrateAxes__
 #define __IntegrateAxes__
 
-#include <iostream>
-#include "SpinWaveGenie/Memory.h"
-#include <vector>
-#include <deque>
-#include "SpinWaveGenie/Plot/SpinWavePlot.h"
-#include "SpinWaveGenie/Containers/HKLDirections.h"
 #include "SpinWaveGenie/Containers/Energies.h"
+#include "SpinWaveGenie/Containers/HKLDirections.h"
+#include "SpinWaveGenie/Export.h"
+#include "SpinWaveGenie/Memory.h"
+#include "SpinWaveGenie/Plot/SpinWavePlot.h"
+#include <deque>
+#include <iostream>
+#include <vector>
 
 namespace SpinWaveGenie
 {
 
-class IntegrateAxes : public SpinWavePlot
+class SPINWAVEGENIE_EXPORT IntegrateAxes : public SpinWavePlot
 {
 public:
   IntegrateAxes(const IntegrateAxes &other);

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/IntegrateEnergy.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/IntegrateEnergy.h
@@ -9,17 +9,18 @@
 #ifndef __spin_wave_genie__IntegrateEnergy__
 #define __spin_wave_genie__IntegrateEnergy__
 
-#include <iostream>
-#include "SpinWaveGenie/Memory.h"
-#include <vector>
-#include <deque>
-#include "SpinWaveGenie/Plot/SpinWavePlot.h"
 #include "SpinWaveGenie/Containers/Energies.h"
+#include "SpinWaveGenie/Export.h"
+#include "SpinWaveGenie/Memory.h"
+#include "SpinWaveGenie/Plot/SpinWavePlot.h"
+#include <deque>
+#include <iostream>
+#include <vector>
 
 namespace SpinWaveGenie
 {
 
-class IntegrateEnergy : public SpinWavePlot
+class SPINWAVEGENIE_EXPORT IntegrateEnergy : public SpinWavePlot
 {
 public:
   IntegrateEnergy(const IntegrateEnergy &other);

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/IntegrateThetaPhi.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/IntegrateThetaPhi.h
@@ -9,15 +9,16 @@
 #ifndef __spin_wave_genie__IntegrateThetaPhi__
 #define __spin_wave_genie__IntegrateThetaPhi__
 
+#include "SpinWaveGenie/Containers/Energies.h"
+#include "SpinWaveGenie/Export.h"
+#include "SpinWaveGenie/Plot/SpinWavePlot.h"
 #include <deque>
 #include <vector>
-#include "SpinWaveGenie/Plot/SpinWavePlot.h"
-#include "SpinWaveGenie/Containers/Energies.h"
 
 namespace SpinWaveGenie
 {
 
-class IntegrateThetaPhi : public SpinWavePlot
+class SPINWAVEGENIE_EXPORT IntegrateThetaPhi : public SpinWavePlot
 {
 public:
   IntegrateThetaPhi(std::unique_ptr<SpinWavePlot> object, double tol = 1.0e-4, int maxEvals = 1000)

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/OneDimensionalFactory.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/OneDimensionalFactory.h
@@ -9,14 +9,15 @@
 #ifndef __OneDimensionalFactory__
 #define __OneDimensionalFactory__
 
-#include <iostream>
+#include "SpinWaveGenie/Export.h"
 #include "SpinWaveGenie/Memory.h"
 #include "SpinWaveGenie/Plot/OneDimensionalShapes.h"
+#include <iostream>
 
 namespace SpinWaveGenie
 {
 
-class OneDimensionalFactory
+class SPINWAVEGENIE_EXPORT OneDimensionalFactory
 {
 public:
   std::unique_ptr<OneDimensionalShapes> getGaussian(double fwhm, double tol);

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/OneDimensionalGaussian.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/OneDimensionalGaussian.h
@@ -9,14 +9,15 @@
 #ifndef __OneDimensionalGaussian__
 #define __OneDimensionalGaussian__
 
-#include <iostream>
+#include "SpinWaveGenie/Export.h"
 #include "SpinWaveGenie/Memory.h"
 #include "SpinWaveGenie/Plot/OneDimensionalShapes.h"
+#include <iostream>
 
 namespace SpinWaveGenie
 {
 
-class OneDimensionalGaussian : public OneDimensionalShapes
+class SPINWAVEGENIE_EXPORT OneDimensionalGaussian : public OneDimensionalShapes
 {
 public:
   OneDimensionalGaussian(double FWHM = 1.0, double Tolerance = 0.01);

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/OneDimensionalLorentzian.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/OneDimensionalLorentzian.h
@@ -9,14 +9,15 @@
 #ifndef __OneDimensionalLorentzian__
 #define __OneDimensionalLorentzian__
 
-#include <iostream>
+#include "SpinWaveGenie/Export.h"
 #include "SpinWaveGenie/Memory.h"
 #include "SpinWaveGenie/Plot/OneDimensionalShapes.h"
+#include <iostream>
 
 namespace SpinWaveGenie
 {
 
-class OneDimensionalLorentzian : public OneDimensionalShapes
+class SPINWAVEGENIE_EXPORT OneDimensionalLorentzian : public OneDimensionalShapes
 {
 public:
   void setFWHM(double InFWHM);

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/OneDimensionalPseudoVoigt.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/OneDimensionalPseudoVoigt.h
@@ -9,16 +9,17 @@
 #ifndef __OneDimensionalPseudoVoigt__
 #define __OneDimensionalPseudoVoigt__
 
-#include <iostream>
+#include "SpinWaveGenie/Export.h"
 #include "SpinWaveGenie/Memory.h"
-#include "SpinWaveGenie/Plot/OneDimensionalShapes.h"
-#include "SpinWaveGenie/Plot/OneDimensionalLorentzian.h"
 #include "SpinWaveGenie/Plot/OneDimensionalGaussian.h"
+#include "SpinWaveGenie/Plot/OneDimensionalLorentzian.h"
+#include "SpinWaveGenie/Plot/OneDimensionalShapes.h"
+#include <iostream>
 
 namespace SpinWaveGenie
 {
 
-class OneDimensionalPseudoVoigt : public OneDimensionalShapes
+class SPINWAVEGENIE_EXPORT OneDimensionalPseudoVoigt : public OneDimensionalShapes
 {
 public:
   OneDimensionalPseudoVoigt();

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/OneDimensionalShapes.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/OneDimensionalShapes.h
@@ -9,14 +9,15 @@
 #ifndef __OneDimensionalShapes__
 #define __OneDimensionalShapes__
 
-#include <iostream>
+#include "SpinWaveGenie/Export.h"
 #include "SpinWaveGenie/Memory.h"
+#include <iostream>
 
 namespace SpinWaveGenie
 {
 
 /* Abstract base class */
-class OneDimensionalShapes
+class SPINWAVEGENIE_EXPORT OneDimensionalShapes
 {
 public:
   virtual void setTolerance(double InTolerance) = 0;

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/SpinWaveDispersion.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/SpinWaveDispersion.h
@@ -5,7 +5,7 @@
 #include "SpinWaveGenie/Containers/ThreeVectors.h"
 #include "SpinWaveGenie/Genie/SpinWave.h"
 
-class SpinWaveDispersion
+class SPINWAVEGENIE_EXPORT SpinWaveDispersion
 {
 public:
   SpinWaveDispersion();

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/SpinWavePlot.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/SpinWavePlot.h
@@ -1,18 +1,19 @@
 #ifndef __SpinWavePlot__
 #define __SpinWavePlot__
 
-#include <iostream>
-#include <vector>
 #include "SpinWaveGenie/Containers/Cell.h"
+#include "SpinWaveGenie/Containers/Energies.h"
+#include "SpinWaveGenie/Export.h"
 #include "SpinWaveGenie/Genie/SpinWave.h"
 #include "SpinWaveGenie/Plot/OneDimensionalGaussian.h"
-#include "SpinWaveGenie/Containers/Energies.h"
+#include <iostream>
+#include <vector>
 
 namespace SpinWaveGenie
 {
 
 /* Abstract base class */
-class SpinWavePlot
+class SPINWAVEGENIE_EXPORT SpinWavePlot
 {
 public:
   virtual std::unique_ptr<SpinWavePlot> clone() = 0;

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/TwoDGaussian.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/TwoDGaussian.h
@@ -9,14 +9,15 @@
 #ifndef __spin_wave_genie__TwoDGaussian__
 #define __spin_wave_genie__TwoDGaussian__
 
-#include <iostream>
+#include "SpinWaveGenie/Export.h"
 #include "SpinWaveGenie/Memory.h"
 #include "SpinWaveGenie/Plot/OneDimensionalShapes.h"
+#include <iostream>
 
 namespace SpinWaveGenie
 {
 
-class TwoDGaussian : public OneDimensionalShapes
+class SPINWAVEGENIE_EXPORT TwoDGaussian : public OneDimensionalShapes
 {
 public:
   // void setFWHM(double InFWHM){};

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/TwoDimensionalCut.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/TwoDimensionalCut.h
@@ -10,6 +10,7 @@
 #define __spin_wave_genie__TwoDimensionalCut__
 
 #include "SpinWaveGenie/Containers/ThreeVectors.h"
+#include "SpinWaveGenie/Export.h"
 
 #include <memory>
 
@@ -18,7 +19,7 @@ namespace SpinWaveGenie
 
 class SpinWavePlot;
 
-class TwoDimensionalCut
+class SPINWAVEGENIE_EXPORT TwoDimensionalCut
 {
 public:
   void setFilename(const std::string &name);

--- a/libSpinWaveGenie/include/SpinWaveGenie/Plot/TwoDimensionalGaussian.h
+++ b/libSpinWaveGenie/include/SpinWaveGenie/Plot/TwoDimensionalGaussian.h
@@ -9,13 +9,14 @@
 #ifndef __spin_wave_genie__TwoDimensionalGaussian__
 #define __spin_wave_genie__TwoDimensionalGaussian__
 
+#include "SpinWaveGenie/Containers/Energies.h"
+#include "SpinWaveGenie/Export.h"
+#include "SpinWaveGenie/Genie/SpinWave.h"
+#include "SpinWaveGenie/Plot/EnergyResolutionFunction.h"
+#include "SpinWaveGenie/Plot/SpinWavePlot.h"
+#include <deque>
 #include <iostream>
 #include <vector>
-#include <deque>
-#include "SpinWaveGenie/Genie/SpinWave.h"
-#include "SpinWaveGenie/Plot/SpinWavePlot.h"
-#include "SpinWaveGenie/Containers/Energies.h"
-#include "SpinWaveGenie/Plot/EnergyResolutionFunction.h"
 
 namespace SpinWaveGenie
 {
@@ -26,7 +27,7 @@ struct TwoDimGaussian
   Vector3 direction;
 };
 
-class TwoDimensionResolutionFunction : public SpinWavePlot
+class SPINWAVEGENIE_EXPORT TwoDimensionResolutionFunction : public SpinWavePlot
 {
 public:
   TwoDimensionResolutionFunction(){};


### PR DESCRIPTION
This Fixes #54.

This sets the default visibility to hidden and uses CMake's GenerateExportHeader functionality to generate the proper export header. This should allow the creation of a shared library under Windows.
