### PR TITLE
Find site_packages directory with python3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
       compiler: gcc
       env: PYTHON_VERSION=3.4
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode8
       compiler: clang
       env: PYTHON_VERSION=3.5
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ before_script:
         cmake -DWARNINGS_AS_ERRORS=ON -DCOVERALLS=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON .;
       elif [ "$PYTHON_VERSION" == "3.5" ];
       then
-        cmake -DWARNINGS_AS_ERRORS=ON -DBUILD_TESTING=ON -DPYTHON_LIBRARY=/usr/local/Frameworks/Python.framework/Versions/3.5/lib/libpython3.5m.dylib -DPYTHON_INCLUDE_DIR=/usr/local/Frameworks/Python.framework/Versions/3.5/include/python3.5m -DPYTHON_EXECUTABLE=/usr/local/bin/python3;
+        cmake -DWARNINGS_AS_ERRORS=ON -DBUILD_TESTING=ON -DPYTHON_EXECUTABLE=/usr/local/bin/python3 -DPYTHON_LIBRARY=/usr/local/Frameworks/Python.framework/Versions/3.5/lib/libpython3.5m.dylib;
       else
         cmake -DWARNINGS_AS_ERRORS=ON -DBUILD_TESTING=ON;
       fi
@@ -79,9 +79,9 @@ before_script:
     then
       if [ "$PYTHON_VERSION" == "3.4" ];
       then
-        cmake -DWARNINGS_AS_ERRORS=ON -DBUILD_TESTING=ON -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.4m.so -DPYTHON_INCLUDE_DIR=/usr/include/python3.4 -DPYTHON_EXECUTABLE=/usr/bin/python3;
+        cmake -DWARNINGS_AS_ERRORS=ON -DBUILD_TESTING=ON -DPYTHON_EXECUTABLE=/usr/bin/python3;
       else
-        cmake -DWARNINGS_AS_ERRORS=ON -DBUILD_TESTING=ON -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython2.7.so -DPYTHON_INCLUDE_DIR=/usr/include/python2.7 -DPYTHON_EXECUTABLE=/usr/bin/python2;
+        cmake -DWARNINGS_AS_ERRORS=ON -DBUILD_TESTING=ON;
       fi
     fi
 

--- a/pythonapi/CMakeLists.txt
+++ b/pythonapi/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package(PythonInterp REQUIRED)
 find_package(PythonLibs REQUIRED)
 
 if(NOT PYTHON_SITE_PACKAGES_DIR)
-  execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()"
+  execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(True))"
                     OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
   set( PYTHON_SITE_PACKAGES_DIR ${PYTHON_SITE_PACKAGES} CACHE FILEPATH "site-packages directory for python bindings")
 endif()


### PR DESCRIPTION
This updates the python script returning the `site_packages` directory so that it is python2/3 compatible. I also added an argument so that the platform-dependent directory is returned.

@rosswhitfield Would you try this branch on Arch?
